### PR TITLE
Provide context for renderer

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -592,7 +592,7 @@ class InlineLexer(object):
 
         if line[0] == '!':
             text = escape(text, quote=True)
-            return self.renderer.image(self, link, title, text)
+            return self.renderer.image(link, title, text)
 
         self._in_link = True
         text = self.output(text)
@@ -790,7 +790,7 @@ class Renderer(object):
             return '<a href="%s">%s</a>' % (link, text)
         return '<a href="%s" title="%s">%s</a>' % (link, title, text)
 
-    def image(self, inline_lexer, src, title, text):
+    def image(self, src, title, text):
         """Rendering a image with title and text.
 
         :param src: source link of the image.


### PR DESCRIPTION
Great work on this; it is indeed fast!

Would you consider a change something like the prototype in this pull request? It provides the inline_lexer to the renderer method and sets a couple extra values that can be used for more advanced rendering.

Of course, a full implementation would change all the renderer methods to accept the lexer as an argument and would be breaking backwards compatibility, but it is a very new project so maybe it is in time? If so, I'm willing to make the change and submit it.

In the exact example usage I'm thinking of, I detect if an image is all alone or surrounded by other elements. Depending on its surroundings or lack thereof, I change the rendered CSS class. So for example, an image followed by text all in one paragraph might float the image left and flow the text around it.

Maybe an image would better explain:

![sample](https://f.cloud.github.com/assets/611567/2303624/9f1c31f2-a1d5-11e3-8122-e66e65d36489.jpg)
