### PR TITLE
Make code examples more explicit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,7 +188,7 @@ It is an inline grammar, which requires custom ``InlineGrammar`` and
 You should pass the inline lexer to ``Markdown`` parser::
 
     renderer = MyRenderer()
-    minline = MyInlineLexer(renderer)
+    inline = MyInlineLexer(renderer)
     markdown = Markdown(renderer, inline=inline)
     markdown('[[Link Text|Wiki Link]]')
 


### PR DESCRIPTION
I love working with mistune but in the beginning I was getting a bit confused by the examples in README.rst for the lexers. After finding out what was missing in the example to get it to work I added the details to the README so no one else will be confused by little missing pieces in the example code (missing imports and not showing how 'renderer' is instantiated). Hope you like it.
