### PR TITLE
fix renderer options

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -897,6 +897,7 @@ class Markdown(object):
             renderer = Renderer(**kwargs)
 
         self.renderer = renderer
+        self.renderer.options.update(kwargs)
 
         if inline and inspect.isclass(inline):
             inline = inline(renderer, **kwargs)

--- a/tests/test.py
+++ b/tests/test.py
@@ -156,13 +156,14 @@ def test_token_tree():
     """Tests a Renderer that returns a list from the placeholder method."""
 
     class CustomRenderer(mistune.Renderer):
+        NO_FAKES = ('options', 'placeholder')
+
         def placeholder(self):
             return []
 
         def __getattribute__(self, name):
             """Saves the arguments to each Markdown handling method."""
-            found = CustomRenderer.__dict__.get(name)
-            if found:
+            if name in CustomRenderer.NO_FAKES:
                 return object.__getattribute__(self, name)
 
             def fake_method(*args, **kwargs):


### PR DESCRIPTION
If I pass a Renderer instance to the Markdown parser, the renderer won't get the options I set to the Markdown parser.
So, I think we should update the renderer's options manually.

plz review, thx.