### PR TITLE
Contents of inline html should be parsed?

### DIFF
--- a/tests/fixtures/normal/inline_html_wrap_span.html
+++ b/tests/fixtures/normal/inline_html_wrap_span.html
@@ -1,0 +1,1 @@
+<a href="foo" title="bar"><img src="image.svg" /></a>

--- a/tests/fixtures/normal/inline_html_wrap_span.text
+++ b/tests/fixtures/normal/inline_html_wrap_span.text
@@ -1,0 +1,1 @@
+<a href="foo" title="bar">![](image.svg)</a>


### PR DESCRIPTION
Turns out the fix of #38 didn't fix the nbviewer downstream issue (https://github.com/jupyter/nbviewer/issues/458). He's using `<center>`, which is another store, but is expose with more normal tags like `<a>` as in the test case.

From our point of view, this is a bug as `marked` (used in the live notebook) will indeed render this as a user expects. If that's not the case here, we'll need to figure out some way to add the behavior, but that is some fearsome regexen there... though the new one is cleaner!