### PR TITLE
Match autolinks that do not have / in their URI

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -425,7 +425,7 @@ class InlineGrammar(object):
             r'''<(?:%s)(?:"[^"]*"|'[^']*'|[^'">])*?>''' % _inline_tag,
         )
     )
-    autolink = re.compile(r'^<([^ >]+(@|:\/)[^ >]+)>')
+    autolink = re.compile(r'^<([^ >]+(@|:)[^ >]+)>')
     link = re.compile(
         r'^!?\[('
         r'(?:\[[^^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*'


### PR DESCRIPTION
This expands the range of matchable URIs quite a bit by dropping the requirement for a / after the :

#52