### PR TITLE
fix module import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Here is an example of code highlighting:
     import mistune
     from pygments import highlight
     from pygments.lexers import get_lexer_by_name
-    from pygments.formatters import HtmlFormatter
+    from pygments.formatters import html
 
     class HighlightRenderer(mistune.Renderer):
         def block_code(self, code, lang):
@@ -119,7 +119,7 @@ Here is an example of code highlighting:
                 return '\n<pre><code>%s</code></pre>\n' % \
                     mistune.escape(code)
             lexer = get_lexer_by_name(lang, stripall=True)
-            formatter = HtmlFormatter()
+            formatter = html.HtmlFormatter()
             return highlight(code, lexer, formatter)
 
     renderer = HighlightRenderer()


### PR DESCRIPTION
sorry for that I can not import "HtmlFormattor" in module "pygments.formatters",but I found it under "html" which is imported from module "pygments.formatters".

