### PR TITLE
Fix #80 and #87

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -78,7 +78,7 @@ def escape_link(url, **kwargs):
         scheme, _ = url.split(':', 1)
         scheme = _nonalpha_pattern.sub('', scheme)
         # whitelist would be better but mistune's use case is too general
-        if scheme in _scheme_blacklist:
+        if scheme.lower() in _scheme_blacklist:
             return ''
     # escape &entities; to &amp;entities;
     kwargs['smart_amp'] = False

--- a/tests/fixtures/normal/amps_and_angles_encoding.html
+++ b/tests/fixtures/normal/amps_and_angles_encoding.html
@@ -8,10 +8,10 @@
 
 <p>6 &gt; 5.</p>
 
-<p>Here's a <a href="http://example.com/?foo=1&bar=2">link</a> with an ampersand in the URL.</p>
+<p>Here's a <a href="http://example.com/?foo=1&amp;bar=2">link</a> with an ampersand in the URL.</p>
 
 <p>Here's a link with an amersand in the link text: <a href="http://att.com/" title="AT&amp;T">AT&amp;T</a>.</p>
 
-<p>Here's an inline <a href="/script?foo=1&bar=2">link</a>.</p>
+<p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a>.</p>
 
-<p>Here's an inline <a href="/script?foo=1&bar=2">link</a>.</p>
+<p>Here's an inline <a href="/script?foo=1&amp;bar=2">link</a>.</p>

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -21,6 +21,8 @@ def test_safe_links():
     attack_vectors = (
         # "standard" javascript pseudo protocol
         ('javascript:alert`1`', ''),
+        # bypass attempt
+        ('jAvAsCrIpT:alert`1`', ''),
         # javascript pseudo protocol with entities
         ('javascript&colon;alert`1`', 'javascript&amp;colon;alert`1`'),
         # javascript pseudo protocol with prefix (dangerous in Chrome)


### PR DESCRIPTION
In order to fix #80, a simple call to escape is sufficient. However, #87 is actually a beast. It is fairly easy to fix if you would use a whitelist of allowed schemes (HTTP, HTTPS, ...) but for a general markdown parser I figured this would be too much of a burden to use for developers. You probably expect things to just work. Thus, I attempted to implement a blacklist. The attack vectors this could should protect against are listed in the test case, but here is an explanation for each of them:

- ``javascript:alert`1```: Standard. You protected against this already.
- ``jAvAsCrIpT:alert`1```: Just a little variation on the original vector (still works in every browser)
- ``javascript&colon;alert`1```: The entity attack. Every browser will first decode the entity and then execute our payload (https://jsfiddle.net/kLv02bun/).
- ``\x1Ajavascript:alert`1```: The "weird" one. Different browsers allow different characters in front of (and after) a scheme. This vector is for Chrome (https://jsfiddle.net/fxdfn1g6/). This is the reason I had to cut out nonalphanumeric characters in the escape_link function.
- ``data:text/html,<script>alert`1```</script>: Just a variation on the scheme. Even though it alerts in every browser, it is actually only a danger in Firefox.
- ``vbscript:msgbox``: Protect against old Internet Explorer XSS. For good measure.

Note, that I had to fix an unrelated test case which used links. As far as my understanding of the HTML spec goes, it is more correct now, as & always has to be transformed to ``&amp;`` due to its special meaning.