### PR TITLE
Correctly handle e-mail addresses using autolink when the email username contains a '.'

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -499,7 +499,7 @@ class InlineLexer(object):
     grammar_class = InlineGrammar
 
     default_rules = [
-        'escape', 'inline_html', 'autolink', 'url',
+        'escape', 'autolink', 'inline_html', 'url',
         'footnote', 'link', 'reflink', 'nolink',
         'double_emphasis', 'emphasis', 'code',
         'linebreak', 'strikethrough', 'text',

--- a/tests/fixtures/extra/autolink_lines.html
+++ b/tests/fixtures/extra/autolink_lines.html
@@ -1,3 +1,4 @@
 <p>hello world
 <a href="http://example.com">http://example.com</a>
-</p>
+</p><a href="mailto:me.too@email.domain">me.too@email.domain</a>
+

--- a/tests/fixtures/extra/autolink_lines.text
+++ b/tests/fixtures/extra/autolink_lines.text
@@ -1,2 +1,4 @@
 hello world
 <http://example.com>
+
+<me.too@email.domain>

--- a/tests/fixtures/normal/auto_email.html
+++ b/tests/fixtures/normal/auto_email.html
@@ -1,2 +1,4 @@
 <p>This should be a link:
 <a href="mailto:me@example.com">me@example.com</a>.</p>
+<p>This should also be a link:
+<a href="mailto:me.too@example.com">me.too@example.com</a>.</p>

--- a/tests/fixtures/normal/auto_email.text
+++ b/tests/fixtures/normal/auto_email.text
@@ -1,1 +1,3 @@
 This should be a link: <me@example.com>.
+
+This should also be a link: <me.too@example.com>.


### PR DESCRIPTION
The built in Lexer / Renderer pair fails when an e-mail address is included which contains a '.' in the username. Instead of reaching the inline lexer for autolink, it's caught by block_html in the BlockLexer and rendered using block_html of the renderer.

```
>>> import mistune
>>> c = '<me.too@email.domain>'
>>> mistune.markdown(c)
'&lt;me.too@email.domain&gt;'
```

As seen below, it works fine when the email address does not contain '.' before the '@'

```
>>> c = '<me@email.domain>'
>>> mistune.markdown(c)
'<p><a href="mailto:me@email.domain">me@email.domain</a></p>\n'
```
When the line contains more than just the email address, a similar problem occurs resulting in rendering using inline_html.

```
>>> c = 'My Name <me.too@email.domain>'
>>> mistune.markdown(c)
'<p>My Name &lt;me.too@email.domain&gt;</p>\n'
```

The problem in the inline case seems to be overcome by changing the order of default_rules in InlineLexer, and making autolink appear before inline_html.
