### PR TITLE
Allows trailing whitespace before closing > in inline/block html

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -159,7 +159,7 @@ class BlockGrammar(object):
     block_html = re.compile(
         r'^ *(?:%s|%s|%s) *(?:\n{2,}|\s*$)' % (
             r'<!--[\s\S]*?-->',
-            r'<(%s)((?:%s)*?)>([\s\S]+?)<\/\1>' % (_block_tag, _valid_attr),
+            r'<(%s)((?:%s)*?)\s*>([\s\S]+?)<\/\1>' % (_block_tag, _valid_attr),
             r'<%s(?:%s)*?\s*\/?>' % (_block_tag, _valid_attr),
         )
     )
@@ -449,7 +449,7 @@ class InlineGrammar(object):
     inline_html = re.compile(
         r'^(?:%s|%s|%s)' % (
             r'<!--[\s\S]*?-->',
-            r'<(\w+%s)((?:%s)*?)>([\s\S]*?)<\/\1>' % (_valid_end, _valid_attr),
+            r'<(\w+%s)((?:%s)*?)\s*>([\s\S]*?)<\/\1>' % (_valid_end, _valid_attr),
             r'<\w+%s(?:%s)*?\s*\/?>' % (_valid_end, _valid_attr),
         )
     )

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -77,6 +77,12 @@ def test_parse_inline_html():
     assert 'href' not in ret
 
 
+def test_block_html():
+    ret = mistune.markdown(
+        '<div ></div>', escape=False
+    )
+    assert '<div ></div>' in ret
+
 def test_parse_block_html():
     ret = mistune.markdown(
         '<div>**foo**</div>', parse_block_html=True, escape=False


### PR DESCRIPTION
Previously the regexp expected the closing first tag to contain zero
whitespace between the last property and the closing angle bracket.

As a result, the code `<a href="bar" >foo</a>` would render incorrectly
as `<p><a href="bar" >foo&lt;/a&gt;</p>\n`

This change applies to unescaped inline and block elements.

Fixes #104