### PR TITLE
Fixes `escape_link` for `\x1a` prefixed url schemes

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -74,7 +74,7 @@ def escape(text, quote=False, smart_amp=True):
 
 def escape_link(url, **kwargs):
     """Remove dangerous URL schemes like javascript: and escape afterwards."""
-    lower_url = url.lower()
+    lower_url = url.lower().strip('\x00\x1a \n\r\t')
     for scheme in _scheme_blacklist:
         if lower_url.startswith(scheme):
             return ''


### PR DESCRIPTION
The previous implementation was vulnerable to schemes prefixed with
\x1a and \x00 and causing master to fail travis build.

Instead of checking for these escape whitespace characters in the link
regex, this removes them right before doing the check for the scheme.