### PR TITLE
Handle block HTML with no content

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -155,7 +155,7 @@ class BlockGrammar(object):
     block_html = re.compile(
         r'^ *(?:%s|%s|%s) *(?:\n{2,}|\s*$)' % (
             r'<!--[\s\S]*?-->',
-            r'<(%s)((?:%s)*?)\s*>([\s\S]+?)<\/\1>' % (_block_tag, _valid_attr),
+            r'<(%s)((?:%s)*?)>([\s\S]*?)<\/\1>' % (_block_tag, _valid_attr),
             r'<%s(?:%s)*?\s*\/?>' % (_block_tag, _valid_attr),
         )
     )

--- a/tests/fixtures/normal/inline_html_simple.html
+++ b/tests/fixtures/normal/inline_html_simple.html
@@ -70,3 +70,13 @@ Blah
 <hr class="foo" id="bar"/>
 
 <hr class="foo" id="bar" >
+
+<p>iframe:</p>
+
+<iframe width="100%" height="410" frameborder="0" allowfullscreen="allowfullscreen" src="https://www.youtube.com/embed/lTWTCwuPdrU?autoplay=0&fs=1"></iframe>
+
+<p>iframe with content:</p>
+
+<iframe src="https://example.com">
+  whee
+</iframe>

--- a/tests/fixtures/normal/inline_html_simple.text
+++ b/tests/fixtures/normal/inline_html_simple.text
@@ -67,3 +67,12 @@ Hr's:
 
 <hr class="foo" id="bar" >
 
+iframe:
+
+<iframe width="100%" height="410" frameborder="0" allowfullscreen="allowfullscreen" src="https://www.youtube.com/embed/lTWTCwuPdrU?autoplay=0&fs=1"></iframe>
+
+iframe with content:
+
+<iframe src="https://example.com">
+  whee
+</iframe>


### PR DESCRIPTION
`<iframe>`s are commonly used with no content. I found this bug while investigating https://github.com/lektor/lektor-website/issues/106