### PR TITLE
Fixes for blank last cell in table

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -368,7 +368,10 @@ class BlockLexer(object):
     def parse_table(self, m):
         item = self._process_table(m)
 
-        cells = re.sub(r'(?: *\| *)?\n$', '', m.group(3))
+        #cells = re.sub(r'(?: *\| *)?\n$', '', m.group(3))
+        cells = re.sub(r' *\n$', '', m.group(3))
+ 
+        
         cells = cells.split('\n')
         for i, v in enumerate(cells):
             v = re.sub(r'^ *\| *| *\| *$', '', v)

--- a/tests/fixtures/extra/gfm_tables.html
+++ b/tests/fixtures/extra/gfm_tables.html
@@ -34,4 +34,23 @@
 		<tr><td style="text-align:left">Cell 1</td><td style="text-align:center">Cell 2</td><td style="text-align:right">Cell 3</td><td>Cell 4</td></tr>
 		<tr><td style="text-align:left"><em>Cell 5</em></td><td style="text-align:center">Cell 6</td><td style="text-align:right">Cell 7</td><td>Cell 8</td></tr>
 	</tbody>
+</table>  
+<pre><code>Blank last cell(s)</code></pre>
+<table>
+	<thead>
+		<tr><th style="text-align:left">Header 1</th><th style="text-align:center">Header 2</th><th style="text-align:right">Header 3</th><th>Header 4</th></tr>
+	</thead>
+	<tbody>
+		<tr><td style="text-align:left"></td><td style="text-align:center"></td><td style="text-align:right"></td><td></td></tr>
+		<tr><td style="text-align:left"><em></em></td><td style="text-align:center"></td><td style="text-align:right"></td><td></td></tr>
+	</tbody>
+</table>  
+<table> 
+	<thead>
+		<tr><th style="text-align:center">Header 1</th><th style="text-align:right">Header 2</th><th style="text-align:left">Header 3</th><th>Header 4</th></tr>
+	</thead>
+	<tbody>
+		<tr><td style="text-align:center"></td><td style="text-align:right"></td><td style="text-align:left"></td><td></td></tr>
+		<tr><td style="text-align:center"></td><td style="text-align:right"></td><td style="text-align:left"></td><td></td></tr>
+	</tbody>
 </table>

--- a/tests/fixtures/extra/gfm_tables.text
+++ b/tests/fixtures/extra/gfm_tables.text
@@ -1,7 +1,7 @@
-| Heading 1 | Heading 2
-| --------- | ---------
-| Cell 1    | Cell 2
-| Cell 3    | Cell 4
+| Heading 1 | Heading 2 |
+| --------- | --------- |
+| Cell 1    | Cell 2   |
+| Cell 3    | Cell 4   |
 
 | Header 1 | Header 2 | Header 3 | Header 4 |
 | :------: | -------: | :------- | -------- |
@@ -9,7 +9,7 @@
 | Cell 5   | Cell 6   | Cell 7   | Cell 8   |
 
     Test code
-
+   
 Header 1 | Header 2
 -------- | --------
 Cell 1   | Cell 2
@@ -19,3 +19,16 @@ Header 1|Header 2|Header 3|Header 4
 :-------|:------:|-------:|--------
 Cell 1  |Cell 2  |Cell 3  |Cell 4
 *Cell 5*|Cell 6  |Cell 7  |Cell 8
+
+    Blank last cell(s)
+  
+
+Header 1|Header 2|Header 3|Header 4
+:-------|:------:|-------:|--------
+ |  | |
+* *| ||
+
+| Header 1 | Header 2 | Header 3 | Header 4 |
+| :------: | -------: | :------- | -------- |
+| |    |   | |
+| |   |  |  |  


### PR DESCRIPTION
The original code uses a split on \n to divide the block into rows and a split on pipe to divide each row into cells.
Markdown however optionally allows leading and trailing pipes on each row so these have to be removed before the split otherwise spurious cells will be created. Similarly if there is a \n at the end of the block this also has to be removed to prevent a spurious row being generated.
Unfortunately the original code for removing the final \n also removes the final pipe. This does not matter if the final cell is not blank but if it is then another pipe will be removed when the row is processed leading to the final cell of the table not being generated.  This fix changes the regex so that only the final \n is removed.
