### PR TITLE
Run as script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,14 @@ It is the same with block level lexer. It would take a while to understand
 the whole mechanism. But you won't do the trick a lot.
 
 
+Command Line Support
+--------------------
+
+Mistune can be called as a script to transform Markdown to HTML. Example usage::
+
+    python -m mistune < in.md > out.html
+
+
 Contribution & Extensions
 -------------------------
 

--- a/mistune.py
+++ b/mistune.py
@@ -10,6 +10,7 @@
 
 import re
 import inspect
+import sys
 
 __version__ = '0.7.3'
 __author__ = 'Hsiaoming Yang <me@lepture.com>'
@@ -1156,3 +1157,31 @@ def markdown(text, escape=True, **kwargs):
     :param parse_inline_html: parse text only in inline level html.
     """
     return Markdown(escape=escape, **kwargs)(text)
+
+
+def usage():
+    message = (
+        'When run as a script, mistune reads markdown from stdin and writes'
+        ' html to stdout.'
+        '\n'
+        'Example usage:\n'
+        '\n'
+        '  python -m mistune < in.md > out.html\n'
+    )
+
+    sys.stderr.write(message)
+
+    raise SystemExit(1)
+
+
+def main(argv):
+    if '--help' in argv:
+        usage()
+
+    src_text = sys.stdin.read()
+    dest_text = markdown(src_text)
+    sys.stdout.write(dest_text)
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,55 @@
+import io
+import os
+import unittest
+import sys
+
+import mistune
+
+
+tests_dir = os.path.dirname(__file__)
+# Are we running in Python 2.x?
+py2 = sys.version_info < (3,)
+
+
+class MainTestCase(unittest.TestCase):
+    def setUp(self):
+        super(MainTestCase, self).setUp()
+        self._stdin = sys.stdin
+        self._stdout = sys.stdout
+        self._stderr = sys.stderr
+
+    def tearDown(self):
+        super(MainTestCase, self).tearDown()
+        sys.stdin = self._stdin
+        sys.stdout = self._stdout
+        sys.stderr = self._stderr
+
+    def test_display_help(self):
+        # If --help is in argv, a usage is emitted and SystemExit is raised.
+
+        argv = [mistune.__file__, '--help']
+        dest = io.BytesIO() if py2 else io.StringIO()
+        sys.stderr = dest
+
+        # Py26 doesn't have assertIn nor using assertRaises as a context manager.
+        self.assertRaises(SystemExit, mistune.main, argv)
+        self.assertTrue('When run as a script' in dest.getvalue())
+
+    def test_reads_stdin_writes_stdout(self):
+        src = os.path.join(tests_dir, 'fixtures', 'data', 'tree.md')
+        dest = io.BytesIO() if py2 else io.StringIO()
+
+        sys.stdin = open(src)
+        sys.stdout = dest
+
+        mistune.main([mistune.__file__])
+
+        expected = (
+            '<h2>Title here</h2>\n<p>Some text.</p>\n<p>In two paragraphs. And'
+            ' then a list.</p>\n<ul>\n<li>foo</li>\n<li>bar<ol>\n<li>meep</li>'
+            '\n<li>stuff</li>\n</ol>\n</li>\n</ul>\n'
+        )
+
+        self.assertEqual(dest.getvalue(), expected)
+
+


### PR DESCRIPTION
Hello,

These changes add support for running mistune as a script to transform a markdown text file to html.

I've added two tests which use unittest instead of nose because I'm not familiar with nose and wasn't sure of the best way to write the tests using the nose test style.

Fixes #121 

David B.
