### PR TITLE
Use kleene star to allow empty alt text attrs

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -35,7 +35,7 @@ _inline_tags = [
 ]
 _pre_tags = ['pre', 'script', 'style']
 _valid_end = r'(?!:/|[^\w\s@]*@)\b'
-_valid_attr = r'''\s*[a-zA-Z\-](?:\=(?:"[^"]+"|'[^']+'|[^\s'">]+))?'''
+_valid_attr = r'''\s*[a-zA-Z\-](?:\=(?:"[^"]*"|'[^']*'|[^\s'">]+))?'''
 _block_tag = r'(?!(?:%s)\b)\w+%s' % ('|'.join(_inline_tags), _valid_end)
 _scheme_blacklist = ('javascript:', 'vbscript:')
 


### PR DESCRIPTION
Noticed that f7b5239 would exclude `<img src="img.png" alt="">` when that is not only valid but has a particular meaning in the [html5 spec for img's alt attribute values](https://html.spec.whatwg.org/multipage/embedded-content.html#alt) (namely, an empty string indicates that the image is not adding any content that cannot be extracted from nearby text and therefore can be skipped by screen readers).

Also, when do you plan on the next release? 

I noticed this as part of following up on the point that @minrk raised in [this discussion] (https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jupyter/vWb82k5xNlM/M-j1r3UAAwAJ). 