### PR TITLE
combine regexes into single regex and use re.finditer() to speed up parsing

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -441,52 +441,53 @@ class BlockLexer(object):
 class InlineGrammar(object):
     """Grammars for inline level tokens."""
 
-    escape = re.compile(r'^\\([\\`*{}\[\]()#+\-.!_>~|])')  # \* \+ \! ....
+    escape = re.compile(r'\\(?P<escape1>[\\`*{}\[\]()#+\-.!_>~|])')  # \* \+ \! ....
     inline_html = re.compile(
-        r'^(?:%s|%s|%s)' % (
+        r'(?:%s|%s|%s)' % (
             r'<!--[\s\S]*?-->',
-            r'<(\w+%s)((?:%s)*?)\s*>([\s\S]*?)<\/\1>' % (_valid_end, _valid_attr),
+            r'<(?P<inline_html1>\w+%s)(?P<inline_html2>(?:%s)*?)\s*>(?P<inline_html3>[\s\S]*?)<\/(?P=inline_html1)>' %
+            (_valid_end, _valid_attr),
             r'<\w+%s(?:%s)*?\s*\/?>' % (_valid_end, _valid_attr),
         )
     )
-    autolink = re.compile(r'^<([^ >]+(@|:)[^ >]+)>')
+    autolink = re.compile(r'^<(?P<autolink1>[^ >]+(?P<autolink2>@|:)[^ >]+)>')
     link = re.compile(
-        r'^!?\[('
+        r'!?\[(?P<link1>'
         r'(?:\[[^^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*'
         r')\]\('
-        r'''\s*(<)?([\s\S]*?)(?(2)>)(?:\s+['"]([\s\S]*?)['"])?\s*'''
+        r'''\s*(?P<link2><)?(?P<link3>[\s\S]*?)(?(link2)>)(?:\s+['"](?P<link4>[\s\S]*?)['"])?\s*'''
         r'\)'
     )
     reflink = re.compile(
-        r'^!?\[('
+        r'!?\[(?P<reflink1>'
         r'(?:\[[^^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*'
-        r')\]\s*\[([^^\]]*)\]'
+        r')\]\s*\[(?P<reflink2>[^^\]]*)\]'
     )
-    nolink = re.compile(r'^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]')
-    url = re.compile(r'''^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])''')
+    nolink = re.compile(r'!?\[(?P<nolink1>(?:\[[^\]]*\]|[^\[\]])*)\]')
+    url = re.compile(r'''(?P<url1>https?:\/\/[^\s<]+[^<.,:;"')\]\s])''')
     double_emphasis = re.compile(
-        r'^_{2}([\s\S]+?)_{2}(?!_)'  # __word__
+        r'_{2}(?P<double_emphasis1>[\s\S]+?)_{2}(?!_)'  # __word__
         r'|'
-        r'^\*{2}([\s\S]+?)\*{2}(?!\*)'  # **word**
+        r'\*{2}(?P<double_emphasis2>[\s\S]+?)\*{2}(?!\*)'  # **word**
     )
     emphasis = re.compile(
-        r'^\b_((?:__|[^_])+?)_\b'  # _word_
+        r'\b_(?P<emphasis1>(?:__|[^_])+?)_\b'  # _word_
         r'|'
-        r'^\*((?:\*\*|[^\*])+?)\*(?!\*)'  # *word*
+        r'\*(?P<emphasis2>(?:\*\*|[^\*])+?)\*(?!\*)'  # *word*
     )
-    code = re.compile(r'^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)')  # `code`
-    linebreak = re.compile(r'^ {2,}\n(?!\s*$)')
-    strikethrough = re.compile(r'^~~(?=\S)([\s\S]*?\S)~~')  # ~~word~~
-    footnote = re.compile(r'^\[\^([^\]]+)\]')
-    text = re.compile(r'^[\s\S]+?(?=[\\<!\[_*`~]|https?://| {2,}\n|$)')
+    code = re.compile(r'(?P<code1>`+)\s*(?P<code2>[\s\S]*?[^`])\s*(?P=code1)(?!`)')  # `code`
+    linebreak = re.compile(r' {2,}\n(?!\s*$)')
+    strikethrough = re.compile(r'~~(?=\S)(?P<strikethrough1>[\s\S]*?\S)~~')  # ~~word~~
+    footnote = re.compile(r'\[\^(?P<footnote1>[^\]]+)\]')
+    text = re.compile(r'[\s\S]+?(?=[\\<!\[_*`~]|https?://| {2,}\n|$)')
 
     def hard_wrap(self):
         """Grammar for hard wrap linebreak. You don't need to add two
         spaces at the end of a line.
         """
-        self.linebreak = re.compile(r'^ *\n(?!\s*$)')
+        self.linebreak = re.compile(r' *\n(?!\s*$)')
         self.text = re.compile(
-            r'^[\s\S]+?(?=[\\<!\[_*`~]|https?://| *\n|$)'
+            r'[\s\S]+?(?=[\\<!\[_*`~]|https?://| *\n|$)'
         )
 
 
@@ -525,6 +526,8 @@ class InlineLexer(object):
         self._in_footnote = False
         self._parse_inline_html = kwargs.get('parse_inline_html')
 
+        self._cached_regexes = {}
+
     def __call__(self, text, rules=None):
         return self.output(text, rules)
 
@@ -532,6 +535,18 @@ class InlineLexer(object):
         self.footnote_index = 0
         self.links = links or {}
         self.footnotes = footnotes or {}
+
+    def _get_regex(self, rules):
+        tup = tuple(rules)
+        if tup not in self._cached_regexes:
+            def get_pattern(key):
+                return getattr(self.rules, key).pattern
+
+            self._cached_regexes[tup] = re.compile(
+                '|'.join('(?P<%s>(?:%s))' %
+                (key, get_pattern(key)) for key in tup))
+        return self._cached_regexes[tup]
+
 
     def output(self, text, rules=None):
         text = text.rstrip('\n')
@@ -543,94 +558,80 @@ class InlineLexer(object):
 
         output = self.renderer.placeholder()
 
-        def manipulate(text):
-            for key in rules:
-                pattern = getattr(self.rules, key)
-                m = pattern.match(text)
-                if not m:
-                    continue
-                self.line_match = m
-                out = getattr(self, 'output_%s' % key)(m)
-                if out is not None:
-                    return m, out
-            return False  # pragma: no cover
-
-        while text:
-            ret = manipulate(text)
-            if ret is not False:
-                m, out = ret
+        # TODO: Correctly handle ambiguous matches (e.g. undefined footnote vs. text).
+        for match in self._get_regex(rules).finditer(text):
+            key = match.lastgroup
+            out = getattr(self, 'output_%s' % key)(match)
+            #print "key:", key, "value:", match.group(key), "out:", out
+            if out is not None:
                 output += out
-                text = text[len(m.group(0)):]
-                continue
-            if text:  # pragma: no cover
-                raise RuntimeError('Infinite loop at: %s' % text)
-
         return output
 
     def output_escape(self, m):
-        text = m.group(1)
+        text = m.group('escape1')
         return self.renderer.escape(text)
 
     def output_autolink(self, m):
-        link = m.group(1)
-        if m.group(2) == '@':
+        link = m.group('autolink1')
+        if m.group('autolink2') == '@':
             is_email = True
         else:
             is_email = False
         return self.renderer.autolink(link, is_email)
 
     def output_url(self, m):
-        link = m.group(1)
+        link = m.group('url1')
         if self._in_link:
             return self.renderer.text(link)
         return self.renderer.autolink(link, False)
 
     def output_inline_html(self, m):
-        tag = m.group(1)
+        tag = m.group('inline_html1')
         if self._parse_inline_html and tag in _inline_tags:
-            text = m.group(3)
+            text = m.group('inline_html3')
             if tag == 'a':
                 self._in_link = True
                 text = self.output(text, rules=self.inline_html_rules)
                 self._in_link = False
             else:
                 text = self.output(text, rules=self.inline_html_rules)
-            extra = m.group(2) or ''
+            extra = m.group('inline_html2') or ''
             html = '<%s%s>%s</%s>' % (tag, extra, text, tag)
         else:
-            html = m.group(0)
+            html = m.group('inline_html')
         return self.renderer.inline_html(html)
 
     def output_footnote(self, m):
-        key = _keyify(m.group(1))
+        key = _keyify(m.group('footnote1'))
         if key not in self.footnotes:
-            return None
+            return self.renderer.text(m.group('footnote'))
         if self.footnotes[key]:
-            return None
+            return self.renderer.text(m.group('footnote'))
         self.footnote_index += 1
         self.footnotes[key] = self.footnote_index
         return self.renderer.footnote_ref(key, self.footnote_index)
 
     def output_link(self, m):
-        return self._process_link(m, m.group(3), m.group(4))
+        return self._process_link(
+            m.group('link'), m.group('link1'), m.group('link3'), m.group('link4'))
 
     def output_reflink(self, m):
-        key = _keyify(m.group(2) or m.group(1))
+        key = _keyify(m.group('reflink2') or m.group('reflink1'))
         if key not in self.links:
             return None
         ret = self.links[key]
-        return self._process_link(m, ret['link'], ret['title'])
+        return self._process_link(
+            m.group('reflink'), m.group('reflink1'), ret['link'], ret['title'])
 
     def output_nolink(self, m):
-        key = _keyify(m.group(1))
+        key = _keyify(m.group('nolink1'))
         if key not in self.links:
-            return None
+            return self.renderer.text(m.group('nolink'))
         ret = self.links[key]
-        return self._process_link(m, ret['link'], ret['title'])
+        return self._process_link(
+            m.group('nolink'), m.group('nolink1'), ret['link'], ret['title'])
 
-    def _process_link(self, m, link, title=None):
-        line = m.group(0)
-        text = m.group(1)
+    def _process_link(self, line, text, link, title=None):
         if line[0] == '!':
             return self.renderer.image(link, title, text)
 
@@ -640,28 +641,28 @@ class InlineLexer(object):
         return self.renderer.link(link, title, text)
 
     def output_double_emphasis(self, m):
-        text = m.group(2) or m.group(1)
+        text = m.group('double_emphasis2') or m.group('double_emphasis1')
         text = self.output(text)
         return self.renderer.double_emphasis(text)
 
     def output_emphasis(self, m):
-        text = m.group(2) or m.group(1)
+        text = m.group('emphasis2') or m.group('emphasis1')
         text = self.output(text)
         return self.renderer.emphasis(text)
 
     def output_code(self, m):
-        text = m.group(2)
+        text = m.group('code2')
         return self.renderer.codespan(text)
 
     def output_linebreak(self, m):
         return self.renderer.linebreak()
 
     def output_strikethrough(self, m):
-        text = self.output(m.group(1))
+        text = self.output(m.group('strikethrough1'))
         return self.renderer.strikethrough(text)
 
     def output_text(self, m):
-        text = m.group(0)
+        text = m.group('text')
         return self.renderer.text(text)
 
 


### PR DESCRIPTION
I saw that matching individual regular expressions takes a big percentage of mistune's runtime. Therefore, I  combined the inline lexer regular expressions into a single expression. Now we can use `re.finditer()` to iterate over the matches. This is faster since it spends more time in C++ code and less in Python code.  

For the standard benchmark I get a nice speedup:
```
$ python tests/bench.py 
Parsing the Markdown Syntax document 1000 times...
use-re-finditer-mistune: 6.549514
master-mistune: 7.866244
```

The code passes all but one test from `tests/test_cases.py`. The remaining items are: 

1. I haven't looked at the block lexer regular expressions, yet. 
2. The patch doesn't correctly handle ambiguities: e.g., if reflink and nolink match, the patch will try to add only one of them, if that fails, the other is not tried.
3. The match names should be changes to more descriptive names. For now, I just "numbered" them.

Would you be interested in working together towards merging this patch? Do you have an idea how to solve the second item?