### PR TITLE
use string.count() to count spaces

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -349,7 +349,7 @@ class BlockLexer(object):
             lines = text.split('\n')
             whitespace = None
             for line in lines[1:]:
-                space = len(line) - len(line.lstrip())
+                space = line.count(' ')
                 if space and (not whitespace or space < whitespace):
                     whitespace = space
             newlines = [lines[0]]


### PR DESCRIPTION
`len(string) - len(string.strip())` is realy a bad method to count spaces.
you can use `dis.dis` to realize how slow it is.