### PR TITLE
Support an escaped pipe char in a table cell

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -373,9 +373,9 @@ class BlockLexer(object):
         cells = cells.split('\n')
         for i, v in enumerate(cells):
             v = re.sub(r'^ *\| *| *\| *$', '', v)
-            cells[i] = re.split(r' *\| *', v)
+            cells[i] = re.split(r' *(?<!\\)\| *', v)
 
-        item['cells'] = cells
+        item['cells'] = self._process_cells(cells)
         self.tokens.append(item)
 
     def parse_nptable(self, m):
@@ -384,9 +384,9 @@ class BlockLexer(object):
         cells = re.sub(r'\n$', '', m.group(3))
         cells = cells.split('\n')
         for i, v in enumerate(cells):
-            cells[i] = re.split(r' *\| *', v)
+            cells[i] = re.split(r' *(?<!\\)\| *', v)
 
-        item['cells'] = cells
+        item['cells'] = self._process_cells(cells)
         self.tokens.append(item)
 
     def _process_table(self, m):
@@ -411,6 +411,14 @@ class BlockLexer(object):
             'align': align,
         }
         return item
+
+    def _process_cells(self, cells):
+        for i, line in enumerate(cells):
+            for c, cell in enumerate(line):
+                # de-escape any pipe inside the cell here
+                cells[i][c] = re.sub('\\\\\|', '|', cell)
+
+        return cells
 
     def parse_block_html(self, m):
         tag = m.group(1)

--- a/tests/fixtures/extra/gfm_tables.html
+++ b/tests/fixtures/extra/gfm_tables.html
@@ -35,3 +35,12 @@
 		<tr><td style="text-align:left"><em>Cell 5</em></td><td style="text-align:center">Cell 6</td><td style="text-align:right">Cell 7</td><td>Cell 8</td></tr>
 	</tbody>
 </table>
+<table>
+	<thead>
+		<tr><th>Header 1</th><th>Header 2</th></tr>
+	</thead>
+	<tbody>
+		<tr><td>Cell 1</td><td>Cell 2 with a pipe in <code>|</code> inline code</td></tr>
+		<tr><td>Cell 3</td><td>Cell 4 with escaped | pipe for some content</td></tr>
+	</tbody>
+</table>

--- a/tests/fixtures/extra/gfm_tables.text
+++ b/tests/fixtures/extra/gfm_tables.text
@@ -19,3 +19,8 @@ Header 1|Header 2|Header 3|Header 4
 :-------|:------:|-------:|--------
 Cell 1  |Cell 2  |Cell 3  |Cell 4
 *Cell 5*|Cell 6  |Cell 7  |Cell 8
+
+Header 1 | Header 2
+-------- | --------------------------------------------
+Cell 1   | Cell 2 with a pipe in `\|` inline code
+Cell 3   | Cell 4 with escaped \| pipe for some content


### PR DESCRIPTION
So that `\|` in a table cell is not split into cells.