### PR TITLE
Fix minors in tests

### DIFF
--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -23,7 +23,7 @@ def test_safe_links():
         ('javascript:alert`1`', ''),
         # bypass attempt
         ('jAvAsCrIpT:alert`1`', ''),
-        # bypass with newline 
+        # bypass with newline
         ('javasc\nript:alert`1`', ''),
         # javascript pseudo protocol with entities
         ('javascript&colon;alert`1`', 'javascript&amp;colon;alert`1`'),

--- a/tests/test_subclassing.py
+++ b/tests/test_subclassing.py
@@ -9,7 +9,7 @@ root = os.path.dirname(__file__)
 
 
 class MathBlockGrammar(mistune.BlockGrammar):
-    block_math = re.compile("^\$\$(.*?)\$\$", re.DOTALL)
+    block_math = re.compile(r'^\$\$(.*?)\$\$', re.DOTALL)
     latex_environment = re.compile(
         r"^\\begin\{([a-z]*\*?)\}(.*?)\\end\{\1\}",
         re.DOTALL
@@ -41,7 +41,7 @@ class MathBlockLexer(mistune.BlockLexer):
 
 
 class MathInlineGrammar(mistune.InlineGrammar):
-    math = re.compile("^\$(.+?)\$")
+    math = re.compile(r'^\$(.+?)\$')
     text = re.compile(r'^[\s\S]+?(?=[\\<!\[_*`~$]|https?://| {2,}\n|$)')
 
 


### PR DESCRIPTION
This fixes two minor things in tests.
 - Trailing whitespace.
 - Warnings while running test.
```
/Users/lqez/Dev/mistune/tests/test_subclassing.py:12: DeprecationWarning: invalid escape sequence \$
  block_math = re.compile("^\$\$(.*?)\$\$", re.DOTALL)
/Users/lqez/Dev/mistune/tests/test_subclassing.py:44: DeprecationWarning: invalid escape sequence \$
  math = re.compile("^\$(.+?)\$")
```