### PR TITLE
Add fn_prefix option for renderer to use custom prefix for footnote label

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -911,10 +911,11 @@ class Renderer(object):
         :param key: identity key for the footnote.
         :param index: the index count of current footnote.
         """
+        prefix = self.options.get('fn_prefix', 'fn')
         html = (
-            '<sup class="footnote-ref" id="fnref-%s">'
-            '<a href="#fn-%s">%d</a></sup>'
-        ) % (escape(key), escape(key), index)
+            '<sup class="footnote-ref" id="%sref-%s">'
+            '<a href="#%s-%s">%d</a></sup>'
+        ) % (prefix, escape(key), prefix, escape(key), index)
         return html
 
     def footnote_item(self, key, text):
@@ -923,15 +924,16 @@ class Renderer(object):
         :param key: identity key for the footnote.
         :param text: text content of the footnote.
         """
+        prefix = self.options.get('fn_prefix', 'fn')
         back = (
-            '<a href="#fnref-%s" class="footnote">&#8617;</a>'
-        ) % escape(key)
+            '<a href="#%sref-%s" class="footnote">&#8617;</a>'
+        ) % (prefix, escape(key))
         text = text.rstrip()
         if text.endswith('</p>'):
             text = re.sub(r'<\/p>$', r'%s</p>' % back, text)
         else:
             text = '%s<p>%s</p>' % (text, back)
-        html = '<li id="fn-%s">%s</li>\n' % (escape(key), text)
+        html = '<li id="%s-%s">%s</li>\n' % (prefix, escape(key), text)
         return html
 
     def footnotes(self, text):

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -156,3 +156,9 @@ def test_hard_wrap_renderer():
     renderer = mistune.Renderer(hard_wrap=True)
     func = mistune.Markdown(renderer=renderer)
     assert '<br>' in func(text)
+
+
+def test_use_fn_prefix():
+    ret = mistune.markdown('paragraph [^1]\n[^1]: footnote', fn_prefix='footnote')
+    assert '<sup class="footnote-ref" id="footnoteref-1"><a href="#footnote-1">' in ret
+    assert '<li id="footnote-1"><p>footnote<a href="#footnoteref-1" class="footnote">' in ret


### PR DESCRIPTION
This patch adds `fn_prefix` option for `Renderer` to use a custom prefix for footnote label.