### PR TITLE
fix: break shared attr to avoid side-effect

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -204,6 +204,7 @@ class BlockLexer(object):
         self._max_recursive_depth = kwargs.get('max_recursive_depth', 6)
         self._list_depth = 0
         self._blockquote_depth = 0
+        self.default_rules = self.default_rules[:]
 
     def __call__(self, text, rules=None):
         return self.parse(text, rules)
@@ -550,6 +551,8 @@ class InlineLexer(object):
         self._in_link = False
         self._in_footnote = False
         self._parse_inline_html = kwargs.get('parse_inline_html')
+        self.default_rules = self.default_rules[:]
+        self.inline_html_rules = self.inline_html_rules[:]
 
     def __call__(self, text, rules=None):
         return self.output(text, rules)

--- a/tests/test_instance_attr.py
+++ b/tests/test_instance_attr.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+
+import mistune
+
+
+def test_block_lexer():
+
+    bl = mistune.BlockLexer()
+
+    assert bl.default_rules is not mistune.BlockLexer.default_rules
+
+
+def test_inline_lexer():
+
+    r = mistune.Renderer()
+    il = mistune.InlineLexer(r)
+
+    assert il.default_rules is not mistune.InlineLexer.default_rules
+    assert il.inline_html_rules is not mistune.InlineLexer.inline_html_rules


### PR DESCRIPTION
Class attribute such as `default_rules` should be cloned every time creating an instance, or one instance modifying the attribute results in unexpected side effect.