### PR TITLE
Fix SyntaxWarning due to unescaped sequence

### DIFF
--- a/mistune.py
+++ b/mistune.py
@@ -433,7 +433,7 @@ class BlockLexer(object):
         for i, line in enumerate(cells):
             for c, cell in enumerate(line):
                 # de-escape any pipe inside the cell here
-                cells[i][c] = re.sub('\\\\\|', '|', cell)
+                cells[i][c] = re.sub('\\\\\\|', '|', cell)
 
         return cells
 

--- a/mistune.py
+++ b/mistune.py
@@ -433,7 +433,7 @@ class BlockLexer(object):
         for i, line in enumerate(cells):
             for c, cell in enumerate(line):
                 # de-escape any pipe inside the cell here
-                cells[i][c] = re.sub('\\\\\\|', '|', cell)
+                cells[i][c] = re.sub(r'\\\|', '|', cell)
 
         return cells
 


### PR DESCRIPTION
This PR fixes a `SyntaxWarning` on CPython master. This is caused due to unescaped sequences and one possible fix would be to use a raw string here. 

Sample warning on master : 

```
mistune.py:436
  /home/karthi/mistune/mistune.py:436: SyntaxWarning: invalid escape sequence \|
    cells[i][c] = re.sub('\\\\\|', '|', cell)
```