### PR TITLE
add failing test for [**0**]

### DIFF
--- a/tests/fixtures/json/ast.json
+++ b/tests/fixtures/json/ast.json
@@ -20,7 +20,6 @@
       }
     ]
   },
-
   {
     "text": "hello **world**",
     "tokens": [
@@ -39,6 +38,28 @@
                 "text": "world"
               }
             ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "text": "short strong [**0**]",
+    "tokens": [
+      {
+        "type": "paragraph",
+        "children": [
+          {
+            "type": "text",
+            "text": "short strong ["
+          },
+          {
+            "type": "strong",
+            "text": "0"
+          },
+          {
+            "type": "text",
+            "text": "]"
           }
         ]
       }


### PR DESCRIPTION
I was playing with v2 and found what might be a bug.
As I understand, mistune fails to detect strong emphasis on string of 1 character.
Please see the test case I added.
Is it a bug, or is it indented?