### PR TITLE
Fix method name on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Convert Markdown to HTML with ease:
 ```python
 import mistune
 
-mistune.html(your_markdown_text)
+mistune.markdown(your_markdown_text)
 ```
 
 ## Security Reporting


### PR DESCRIPTION
I pulled out the latest version and complains that `.html` method does not exist. I've been happily using the `.markdown` method as is the same on the official documentation.

