### PR TITLE
Add definition list plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cover/
 *.c
 *.so
 venv/
+.python-version

--- a/mistune/plugins/__init__.py
+++ b/mistune/plugins/__init__.py
@@ -1,20 +1,22 @@
-from .extra import plugin_url, plugin_strikethrough
+from .def_list import plugin_def_list
+from .extra import plugin_strikethrough, plugin_url
 from .footnotes import plugin_footnotes
 from .table import plugin_table
 from .task_lists import plugin_task_lists
 
-
 PLUGINS = {
-    'url': plugin_url,
-    'strikethrough': plugin_strikethrough,
-    'footnotes': plugin_footnotes,
-    'table': plugin_table,
-    'task_lists': plugin_task_lists,
+    "url": plugin_url,
+    "strikethrough": plugin_strikethrough,
+    "footnotes": plugin_footnotes,
+    "table": plugin_table,
+    "task_lists": plugin_task_lists,
+    "def_list": plugin_def_list,
 }
 
 __all__ = [
-    'PLUGINS',
-    'plugin_url', 'plugin_strikethrough',
-    'plugin_footnotes',
-    'plugin_table',
+    "PLUGINS",
+    "plugin_url",
+    "plugin_strikethrough",
+    "plugin_footnotes",
+    "plugin_table",
 ]

--- a/mistune/plugins/def_list.py
+++ b/mistune/plugins/def_list.py
@@ -1,0 +1,43 @@
+import re
+
+__all__ = ["plugin_def_list"]
+
+DEFINITION_LIST_PATTERN = re.compile(r"([^\n]+\n(:[ \t][^\n]+\n)+\n?)+")
+
+
+def parse_def_list(block, m, state):
+    lines = m.group(0).split("\n")
+    definition_list_items = []
+    for line in lines:
+        if not line:
+            continue
+        if line.strip()[0] == ":":
+            definition_list_items.append(
+                {"type": "def_list_item", "text": line[1:].strip()}
+            )
+        else:
+            definition_list_items.append(
+                {"type": "def_list_header", "text": line.strip()}
+            )
+    return {"type": "def_list", "children": definition_list_items}
+
+
+def render_html_def_list(text):
+    return "<dl>\n" + text + "</dl>\n"
+
+
+def render_html_def_list_header(text):
+    return "<dt>" + text + "</dt>\n"
+
+
+def render_html_def_list_item(text):
+    return "<dd>" + text + "</dd>\n"
+
+
+def plugin_def_list(md):
+    md.block.register_rule("def_list", DEFINITION_LIST_PATTERN, parse_def_list)
+    md.block.rules.append("def_list")
+    if md.renderer.NAME == "html":
+        md.renderer.register("def_list", render_html_def_list)
+        md.renderer.register("def_list_header", render_html_def_list_header)
+        md.renderer.register("def_list_item", render_html_def_list_item)

--- a/tests/fixtures/def_list.txt
+++ b/tests/fixtures/def_list.txt
@@ -1,0 +1,94 @@
+# Definition Lists
+
+```````````````````````````````` example
+Term
+: definition
+.
+<dl>
+<dt>Term</dt>
+<dd>definition</dd>
+</dl>
+````````````````````````````````
+
+```````````````````````````````` example
+Term
+: definition1
+: definition2
+.
+<dl>
+<dt>Term</dt>
+<dd>definition1</dd>
+<dd>definition2</dd>
+</dl>
+````````````````````````````````
+
+```````````````````````````````` example
+Term
+: definition1
+: definition2
+
+paragraph
+.
+<dl>
+<dt>Term</dt>
+<dd>definition1</dd>
+<dd>definition2</dd>
+</dl>
+<p>paragraph</p>
+````````````````````````````````
+
+```````````````````````````````` example
+First Term
+: This is the definition of the first term.
+
+Second Term
+: This is one definition of the second term.
+: This is another definition of the second term.
+.
+<dl>
+<dt>First Term</dt>
+<dd>This is the definition of the first term.</dd>
+<dt>Second Term</dt>
+<dd>This is one definition of the second term.</dd>
+<dd>This is another definition of the second term.</dd>
+</dl>
+````````````````````````````````
+
+```````````````````````````````` example
+First Term
+: This is the definition of the first term.
+
+Second Term
+: This is one definition of the second term.
+: This is another definition of the second term.
+
+paragraph
+.
+<dl>
+<dt>First Term</dt>
+<dd>This is the definition of the first term.</dd>
+<dt>Second Term</dt>
+<dd>This is one definition of the second term.</dd>
+<dd>This is another definition of the second term.</dd>
+</dl>
+<p>paragraph</p>
+````````````````````````````````
+
+```````````````````````````````` example
+First Term
+: This is the definition of the first term.
+Second Term
+: This is one definition of the second term.
+: This is another definition of the second term.
+
+paragraph
+.
+<dl>
+<dt>First Term</dt>
+<dd>This is the definition of the first term.</dd>
+<dt>Second Term</dt>
+<dd>This is one definition of the second term.</dd>
+<dd>This is another definition of the second term.</dd>
+</dl>
+<p>paragraph</p>
+````````````````````````````````

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,29 +3,27 @@ from tests import BaseTestCase, fixtures
 
 
 def load_plugin(plugin_name, ast=False):
-    _plugin = getattr(plugins, 'plugin_{}'.format(plugin_name))
+    _plugin = getattr(plugins, "plugin_{}".format(plugin_name))
 
     class TestPlugin(BaseTestCase):
-        md = Markdown(
-            renderer=HTMLRenderer(escape=False),
-            plugins=[_plugin]
-        )
+        md = Markdown(renderer=HTMLRenderer(escape=False), plugins=[_plugin])
 
     def test_ast_renderer(self):
         md = Markdown(renderer=AstRenderer(), plugins=[_plugin])
-        data = fixtures.load_json(plugin_name + '.json')
-        self.assertEqual(md(data['text']), data['tokens'])
+        data = fixtures.load_json(plugin_name + ".json")
+        self.assertEqual(md(data["text"]), data["tokens"])
 
     if ast:
-        test_ast_renderer.__doc__ = 'Run {} ast renderer'.format(plugin_name)
-        setattr(TestPlugin, 'test_ast_renderer', test_ast_renderer)
+        test_ast_renderer.__doc__ = "Run {} ast renderer".format(plugin_name)
+        setattr(TestPlugin, "test_ast_renderer", test_ast_renderer)
 
-    TestPlugin.load_fixtures(plugin_name + '.txt')
-    globals()['TestPlugin_' + plugin_name] = TestPlugin
+    TestPlugin.load_fixtures(plugin_name + ".txt")
+    globals()["TestPlugin_" + plugin_name] = TestPlugin
 
 
-load_plugin('url')
-load_plugin('strikethrough')
-load_plugin('footnotes', True)
-load_plugin('table', True)
-load_plugin('task_lists', True)
+load_plugin("url")
+load_plugin("strikethrough")
+load_plugin("footnotes", True)
+load_plugin("table", True)
+load_plugin("task_lists", True)
+load_plugin("def_list")


### PR DESCRIPTION
Creating a new plugin for [definition lists](https://www.markdownguide.org/extended-syntax/#definition-lists). As most of the extended syntax is already supported either in the default HTMLRenderer or via plugins, I think mistune should support this extension.