### PR TITLE
Minor fix for variable replacement in code block.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,9 @@ Using old Mistune? Checkout docs: https://mistune.readthedocs.io/en/v0.8.4/
 Installation
 ------------
 
-Installing Mistune is quite easy with `pip <http://www.pip-installer.org/>`_::
+Installing Mistune is quite easy with `pip <http://www.pip-installer.org/>`_.
+
+.. parsed-literal::
 
     $ pip install mistune==\ |version|
 


### PR DESCRIPTION
This should fix this page: https://mistune.readthedocs.io/en/latest/

where the version replacement isn't working right now.