### PR TITLE
Fix a bug where mistune would append `mailto:` to all URLs with `@`.

### DIFF
--- a/mistune/inline_parser.py
+++ b/mistune/inline_parser.py
@@ -120,7 +120,9 @@ class InlineParser(ScannerParser):
             return 'text', m.group(0)
 
         text = m.group(1)
-        if '@' in text and not text.lower().startswith('mailto:'):
+        if ('@' in text and
+            not text.lower().startswith('mailto:') and
+            not text.lower().startswith('http')):
             link = 'mailto:' + text
         else:
             link = text


### PR DESCRIPTION
Since `@` is a valid character for URLs, we can be a little bit more cautious
before making a parsed auto_link a mailto URL.

Fixes #275