### PR TITLE
Fix parsing of multiline task list items

### DIFF
--- a/mistune/plugins/task_lists.py
+++ b/mistune/plugins/task_lists.py
@@ -3,7 +3,7 @@ import re
 __all__ = ['plugin_task_lists']
 
 
-TASK_LIST_ITEM = re.compile(r'^(\[[ xX]\])\s(\s*\S.*)')
+TASK_LIST_ITEM = re.compile(r'^(\[[ xX]\])\s*')
 
 
 def task_lists_hook(md, tokens, state):
@@ -61,7 +61,7 @@ def _rewrite_list_item(item):
         m = TASK_LIST_ITEM.match(text)
         if m:
             mark = m.group(1)
-            first_child['text'] = m.group(2)
+            first_child['text'] = text[m.end():]
 
             params = item['params']
             if mark == '[ ]':

--- a/mistune/plugins/task_lists.py
+++ b/mistune/plugins/task_lists.py
@@ -3,7 +3,7 @@ import re
 __all__ = ['plugin_task_lists']
 
 
-TASK_LIST_ITEM = re.compile(r'^(\[[ xX]\])\s*')
+TASK_LIST_ITEM = re.compile(r'^(\[[ xX]\])\s+')
 
 
 def task_lists_hook(md, tokens, state):

--- a/tests/fixtures/task_lists.txt
+++ b/tests/fixtures/task_lists.txt
@@ -52,3 +52,13 @@
 <li class="task-list-item"><input class="task-list-item-checkbox" type="checkbox" disabled checked/>baz</li>
 </ol>
 ````````````````````````````````
+
+```````````````````````````````` example
+- [ ] Task list item
+  over two lines
+.
+<ul>
+<li class="task-list-item"><input class="task-list-item-checkbox" type="checkbox" disabled/>Task list item
+over two lines</li>
+</ul>
+````````````````````````````````


### PR DESCRIPTION
Fixes #278.

The problem was that the content of the task list item was taken from a regex group, but the regex did not match new lines. To avoid this kind of problem, instead of using a regex group the matched task list item marker is removed using slicing.

Because the specification seems to allow any number of spaces after the task list item marker, the new regex also allows more than one of them.