### PR TITLE
Make admonition directive html more similar to python-markdown

### DIFF
--- a/mistune/directives/admonition.py
+++ b/mistune/directives/admonition.py
@@ -37,16 +37,18 @@ class Admonition(Directive):
             md.renderer.register('admonition', render_ast_admonition)
 
 
-def render_html_admonition(text, name, title=None):
+def render_html_admonition(text, name, title=""):
     html = '<section class="admonition ' + name + '">\n'
+    if not title:
+        title = name.capitalize()
     if title:
-        html += '<h1>' + title + '</h1>\n'
+        html += '<p class="admonition-title">' + title + '</p>\n'
     if text:
-        html += '<div class="admonition-text">\n' + text + '</div>\n'
+        html += text
     return html + '</section>\n'
 
 
-def render_ast_admonition(children, name, title=None):
+def render_ast_admonition(children, name, title=""):
     return {
         'type': 'admonition',
         'children': children,

--- a/tests/test_directive.py
+++ b/tests/test_directive.py
@@ -17,7 +17,7 @@ class TestPluginAdmonition(TestCase):
         s = '.. note:: Warnning\n\n   message'
         html = md(s)
         self.assertIn('class="admonition note"', html)
-        self.assertIn('<h1>Warnning</h1>', html)
+        self.assertIn('<p class="admonition-title">Warnning</p>', html)
         self.assertIn('<p>message</p>', html)
 
     def test_code_admonition(self):
@@ -25,17 +25,15 @@ class TestPluginAdmonition(TestCase):
         s = '.. note:: Warnning\n\n       print() '
         html = md(s)
         self.assertIn('class="admonition note"', html)
-        self.assertIn('<h1>Warnning</h1>', html)
+        self.assertIn('<p class="admonition-title">Warnning</p>', html)
         self.assertIn('<pre><code>print() \n</code></pre>', html)
 
     def test_note_admonition_no_text(self):
-        md = create_markdown(
-            plugins=[Admonition()]
-        )
+        md = create_markdown(plugins=[Admonition()])
         s = '.. note:: Warnning'
         html = md(s)
         self.assertIn('class="admonition note"', html)
-        self.assertIn('<h1>Warnning</h1>', html)
+        self.assertIn('<p class="admonition-title">Warnning</p>', html)
 
     def test_admonition_options(self):
         md = create_markdown(plugins=[Admonition()])
@@ -43,12 +41,21 @@ class TestPluginAdmonition(TestCase):
         html = md(s)
         self.assertIn('Admonition has no options', html)
 
+    def test_missing_title(self):
+        md = create_markdown(plugins=[Admonition()])
+        s = '.. note::\n\n   message'
+        html = md(s)
+        self.assertIn('<p class="admonition-title">Note</p>', html)
+
+    def test_empty_title(self):
+        md = create_markdown(plugins=[Admonition()])
+        s = '.. note:: ""\n\n   message'
+        html = md(s)
+        self.assertNotIn('<p class="admonition-title">Note</p>', html)
+
     def test_ast_admonition(self):
         data = fixtures.load_json('admonition.json')
-        md = create_markdown(
-            renderer='ast',
-            plugins=[Admonition()]
-        )
+        md = create_markdown(renderer='ast', plugins=[Admonition()])
         # Use JSON to fix the differences between tuple and list
         tokens = json.loads(json.dumps(md(data['text'])))
         self.assertEqual(tokens, data['tokens'])


### PR DESCRIPTION
Right now the block is wrapped inside a <div class="amonition-text"> element, unlike any other markdown renderer. Moreover if the title is not specified the admonition has no title, while it should default to the name of the admonition. This pull request fixes these two issues.