### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 6
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [2.7, 3.6, 3.7, 3.8, 3.9, pypy2, pypy3]
+        python: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy2", "pypy3"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Text Processing :: Markup


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955