### PR TITLE
Mistune.util.escape_url is too aggressive

### DIFF
--- a/mistune/util.py
+++ b/mistune/util.py
@@ -20,7 +20,12 @@ def escape(s, quote=True):
 
 
 def escape_url(link):
-    safe = '/#:()*?=%@+,&'
+    safe = (
+        ':/?#@'           # gen-delims - '[]' (rfc3986)
+        '!$&()*+,;='      # sub-delims - "'" (rfc3986)
+        '%'               # leave already-encoded octets alone
+    )
+
     if html is None:
         return quote(link.encode('utf-8'), safe=safe)
     return html.escape(quote(html.unescape(link), safe=safe))


### PR DESCRIPTION
This adds `';'`, `'!'`, and `'$'` to the set of characters which will be passed unmolested by `mistune.util.escape_url`.  These are all in RFC 3986’s [reserved character list](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) — that is to say: escaping these may change the meaning of a URL.

## Bugs Fixed

I noticed this when a `data:` URL was mangled by the escaping of a semicolon.  The two URLs: `data:text/plain;base64,d293` and `data:text/plain%3Bbase64,d293` are not equivalent (the first has content-type `text/plain`, the second has content-type `text/plain;base64`.)

## Further Discussion

There are three other characters in the RFC 3986 reserved character list which may be worth adding to the list of unescaped octets: `'['`, `']'`, `"'"`.

Escaping square brackets breaks URLs with numeric ipv6 addresses in the netloc (e.g. `http://[::1]/`).
However, I have not yet included these in this PR because doing so breaks the [Backslash-escapes do not work inside autolinks](https://github.com/lepture/mistune/blob/3e8d35215120ac82176f300dd5e20c0bea5464ea/tests/fixtures/commonmark.txt#L8503) test in `tests/fixtures/commonmark.txt`, and I'm not quite sure how sacrosanct those tests are to you.

As for single quotes, I can not come up with an example of a URL scheme that relies on them, but they are in the list of reserved characters, and it would probably be safer not to escape them.
