### PR TITLE
docs: fix simple typo, paramter -> parameter

### DIFF
--- a/docs/directives.rst
+++ b/docs/directives.rst
@@ -76,7 +76,7 @@ TOC plugin::
     )
 
 If **TOC** directive is enabled, the ``heading`` method of renderer will accept
-one more paramter::
+one more parameter::
 
     def heading(self, text, level):
         # without TOC directive


### PR DESCRIPTION
There is a small typo in docs/directives.rst.

Should read `parameter` rather than `paramter`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md