### PR TITLE
Use absolute import in Spoiler example, add markdown syntax

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -123,7 +123,15 @@ the directives part of the documentation. These are defined in the
 
 Let's try to write a "spoiler" directive, which takes a hint::
 
-    from .base import Directive
+    .. spoiler: SPOILER
+    
+        Spoilers in the information age are typically listed with a SPOILER! heading.
+
+
+
+The `Spoiler` directive::
+
+    from mistune.directives import Directive
 
 
     class Spoiler(Directive):


### PR DESCRIPTION
Examples are more helpful if they contain absolute imports, so I can copy/paste them in my own project.

An example of how to use the spoiler tag is also nice to understand the mechanism. This is available in the general sense in https://mistune.readthedocs.io/en/latest/directives.html, but an explicit example here would make it more understandable.

I'm not entirely sure if the provided syntax is correct.