### PR TITLE
Add support for minimum heading level in TOC

### DIFF
--- a/tests/fixtures/directive_toc.txt
+++ b/tests/fixtures/directive_toc.txt
@@ -237,3 +237,28 @@ none
 <h1 id="toc_1">H1</h1>
 <h2 id="toc_2">H2</h2>
 ````````````````````````````````
+
+## Minimum Heading Level
+
+```````````````````````````````` example
+.. toc::
+   :minlevel: 2
+
+# H1
+## H2
+### H3
+.
+<details class="toc" open>
+<summary>Table of Contents</summary>
+<ul>
+<li><a href="#toc_2">H2</a>
+<ul>
+<li><a href="#toc_3">H3</a></li>
+</ul>
+</li>
+</ul>
+</details>
+<h1 id="toc_1">H1</h1>
+<h2 id="toc_2">H2</h2>
+<h3 id="toc_3">H3</h3>
+````````````````````````````````


### PR DESCRIPTION
- Extract level parsing for TOC into separate method
- Add support for `minlevel` for TOC directive

Resolves #323
