### PR TITLE
feat(renderer): add 'cols' keyword argument

### DIFF
--- a/mistune/plugins/table.py
+++ b/mistune/plugins/table.py
@@ -43,8 +43,9 @@ def parse_table(block, m, state):
             return
         rows.append(row)
 
-    children = [thead, {'type': 'table_body', 'children': rows}]
-    state.append_token({'type': 'table', 'children': children})
+    attrs = {"attrs": { "cols": len(thead["children"])}}
+    children = [thead, {'type': 'table_body', 'children': rows, **attrs }]
+    state.append_token({'type': 'table', 'children': children, **attrs})
     return pos
 
 


### PR DESCRIPTION
Hi @lepture 

First of all: Thank you for your work on this excellent library!

I'm implementing a custom renderer for `.odt` Files (LibreOffice). In LibreOffice, the source of a simple table like this

| Head | Head 2 |
| ------- | ------- |
| Body | Body 2 | 

looks like that (sorry, even a minimal example looks quite verbose in ODF):

```xml
   <table:table table:name="Table1" table:style-name="Table1">
    <table:table-column table:style-name="Table1.A" table:number-columns-repeated="2"/>
    <table:table-row>
     <table:table-cell table:style-name="Table1.A1" office:value-type="string">
      <text:p text:style-name="P1">Head</text:p>
     </table:table-cell>
     <table:table-cell table:style-name="Table1.A1" office:value-type="string">
      <text:p text:style-name="P1">Head 2</text:p>
     </table:table-cell>
    </table:table-row>
    <table:table-row>
     <table:table-cell table:style-name="Table1.A1" office:value-type="string">
      <text:p text:style-name="P1">Body</text:p>
     </table:table-cell>
     <table:table-cell table:style-name="Table1.A1" office:value-type="string">
      <text:p text:style-name="P1">Body 2</text:p>
     </table:table-cell>
    </table:table-row>
   </table:table>
```

Unlike with HTML, LibreOffice needs to know the amount of columns at the beginning of the table. When implementing `table(self, text)`, this information is not easily available because all the children have already been rendered. This PR shows how I solved this issue locally. If you'd be willing to accept a PR adding this as context, I'd be happy to clean it up, add more tests etc. Or would you suggest another way to solve this?

You can find the current WIP state of the renderer here: https://github.com/adfinis/mistune-odt/blob/master/convert.py

Thank you in advance!