### PR TITLE
Add try/except to toc_hook in toc.py

### DIFF
--- a/mistune/toc.py
+++ b/mistune/toc.py
@@ -28,7 +28,10 @@ def add_toc_hook(md, min_level=1, max_level=3, heading_id=None):
         headings = []
 
         for tok in state.tokens:
-            level = tok['attrs']['level']
+            try:
+                level = tok['attrs']['level']
+            except:
+                pass
             if tok['type'] == 'heading' and min_level <= level <= max_level:
                 headings.append(tok)
 


### PR DESCRIPTION
Trying to create a table of contents using add_toc_hook (https://mistune.lepture.com/en/latest/api.html#module-mistune.directives) **fails**
```
File "~/Python/mistune/venv/lib/python3.10/site-packages/mistune/toc.py", line 31, in toc_hook
     level = tok['attrs']['level']
KeyError: 'attrs'
```
Code for reproduce
```python
import mistune
# from mistune.directives import DirectiveToc
from mistune.toc import add_toc_hook, render_toc_ul

md = mistune.create_markdown(
    escape=False, plugins=[])
add_toc_hook(md, max_level=5 )

name = 'Update_fix.md'
with open(name) as f:
    file_content = f.read()
    html, state = md.parse(file_content)
    toc_items = state.env['toc_items']
    toc_html = render_toc_ul(toc_items)
    print(toc_html+html)
```


