### PR TITLE
Add some information for customizing the MarkdownRenderer

### DIFF
--- a/docs/renderers.rst
+++ b/docs/renderers.rst
@@ -92,5 +92,42 @@ RestructuredText Renderer
 -------------------------
 
 
-Markdown Renderer
------------------
+Customize Markdown Renderer
+---------------------------
+
+You can customize Markdown output with your own renderers. Create a subclass
+of ``mistune.MarkdownRenderer``::
+
+
+    class MyRenderer(mistune.renderers.markdown.MarkdownRenderer):
+        def link(self, token, state):
+            return '**' + self.render_children(token, state) + '** '
+
+    # use customized renderer
+    markdown = mistune.create_markdown(renderer=MyRenderer())
+    print(markdown('[Mistune](mistune.lepture.com)'))
+
+Here is a a list of available renderer functions::
+
+    # inline level
+    text(self, token, state)
+    link(self, token, state)
+    image(self, token, state)
+    emphasis(self, token, state)
+    strong(self, token, state)
+    codespan(self, token, state)
+    linebreak(self, token, state)
+    softbreak(self, token, state)
+    inline_html(self, token, state)
+
+    # block level
+    paragraph(self, token, state)
+    heading(self, token, state)
+    blank_line(self, token, state)
+    thematic_break(self, token, state)
+    block_text(self, token, state)
+    block_code(self, token, state)
+    block_quote(self, token, state)
+    block_html(self, token, state)
+    block_error(self, token, state)
+    list(self, token, state)

--- a/docs/renderers.rst
+++ b/docs/renderers.rst
@@ -92,7 +92,7 @@ RestructuredText Renderer
 -------------------------
 
 
-Customize Markdown Renderer
+Customize MarkdownRenderer
 ---------------------------
 
 You can customize Markdown output with your own renderers. Create a subclass


### PR DESCRIPTION
I recently used Mistune to perform custom rendering of Markdown documents from a source Markdown document (mostly removing some syntax). I enjoyed using it, but I spent some amount of time reading the code and theorizing about how the `MarkdownRenderer` is the same as or is different from the `HTMLRenderer` (which has more coverage in the docs)

This PR adds information to the Renderers page (following the example of the HTMLRender) with a small example to rewrite links into bold text.