### PR TITLE
keep leading unicode spaces like emsp (full-width space)

### DIFF
--- a/src/mistune/markdown.py
+++ b/src/mistune/markdown.py
@@ -53,7 +53,8 @@ class Markdown:
             elif 'text' in tok:
                 text = tok.pop('text')
                 # process inline text
-                tok['children'] = self.inline(text.strip(), state.env)
+                # avoid striping emsp or other unicode spaces
+                tok['children'] = self.inline(text.strip(' \r\n\t\f'), state.env)
             yield tok
 
     def parse(self, s: str, state: Optional[BlockState]=None):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -96,3 +96,10 @@ class TestMiscCases(TestCase):
             },
         ]
         self.assertEqual(result, expected)
+
+
+    def test_emsp(self):
+        md = mistune.create_markdown(escape=False, hard_wrap=True)
+        result = md('\u2003\u2003foo\nbar\n\n\u2003\u2003foobar')
+        expected = '<p>\u2003\u2003foo<br />\nbar</p>\n<p>\u2003\u2003foobar</p>'
+        self.assertEqual(result.strip(), expected)


### PR DESCRIPTION
It's not an uncommon habit in writing to have a few leading space at the beginning of each paragraph. However, it turns out to be difficult to achieve in Markdown as the standard interpret leading spaces to be code blocks. 

A common workaround is to use non-common unicode spaces like emsp(`'\u2003'` in python string) to have parser treat them as normal characters. It works well in many mainstream implementations like Obsidian and etc.

However, this workaround does not work in mistune, since mistune leverage `strip()` in various places, which in modern python implementations strips all unicode spaces by default unless a specific list is given.

The patch is to fix it by giving a specific list of known space-like characters to strip. I'm not sure if it's perfect or complete, but it does solves some immediate pain point in most common use cases. Hopefully it can be accepted and fixed. 

Thanks for consideration! and by the way really appreciate your great work in mistune.