### PR TITLE
Please add py.typed so mypy will use and respect type annotations in mistune

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,5 @@ from setuptools import setup
 
 setup(
     name="mistune",
+    package_data={"mistune": ["py.typed", ]}
 )

--- a/src/mistune/py.typed
+++ b/src/mistune/py.typed
@@ -1,0 +1,2 @@
+# when type checking dependents, tell type checkers, e.g. mypy, to use this package's types
+# without this file, mypy will write a warning and ignore type annotations from mistune.


### PR DESCRIPTION
Mypy will complain that it can't check types for mistune despite someone taking the time to annotate mistune because it lacks a `py.typed` file to signal that it is safe to use the type annotations in mistune.

No python touched. I'm assuming you are using `python -m build` as show in in Makefile.l

I tested with 

`clear && rm -rf dist && python -m build && python -m zipfile --list dist/*.whl`

and got

> Successfully built mistune-3.0.0.tar.gz and mistune-3.0.0-py3-none-any.whl
> File Name                                             Modified             Size
> <snip>
> mistune/markdown.py                            2023-06-08 16:33:38         3319
> mistune/**py.typed**                               2023-06-08 16:33:38          181
> mistune/toc.py                                 2023-06-08 16:33:38         3136

No library code was touched & unless someone runs mypy, this has no impact on how the library works.