### PR TITLE
Include more files in sdist explicitly

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+# include all test files but avoid including .pyc
+recursive-include benchmark *.py *.txt
+recursive-include tests *.json *.html *.md *.py *.txt
+# include documentation sources but not built docs
+graft docs
+prune docs/_build


### PR DESCRIPTION
Include documentation sources and test files in sdist archives, to make them more useful to distribution packagers.

Fixes #346