### PR TITLE
fix list parsing edge case

### DIFF
--- a/src/mistune/list_parser.py
+++ b/src/mistune/list_parser.py
@@ -13,7 +13,7 @@ LIST_PATTERN = (
     r'(?P<list_3>[ \t]*|[ \t].+)$'
 )
 
-_LINE_HAS_TEXT = re.compile(r'( *)\S')
+_LINE_HAS_TEXT = re.compile(r'(\s*)\S')
 
 
 def parse_list(block, m: re.Match, state: BlockState) -> int:


### PR DESCRIPTION
fix an incorrect list parsing (text dropped) in situations like:

```
1. item 1
2. \xA0 item 2
```

The second list item text is dropped because first non-space character happens to match `\s` regex pattern.

There are alternative fixes:

* change regex to `( *)[^ ]`.
* use `text.isspace()` and `text.lstrip()` instead of regex matching.