### PR TITLE
Add Script CLI Entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,9 @@
 name = "mistune"
 description = "A sane and fast Markdown parser with useful plugins and renderers"
 authors = [{name = "Hsiaoming Yang", email="me@lepture.com"}]
-dependencies = []
+dependencies = [
+  'typing_extensions >=4.6, <5; python_version < "3.11"'
+]
 license = {text = "BSD-3-Clause"}
 dynamic = ["version"]
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ Documentation = "https://mistune.lepture.com/"
 Source = "https://github.com/lepture/mistune"
 Donate = "https://github.com/sponsors/lepture"
 
+[project.scripts]
+mistune = "mistune.__main__:cli"
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"

--- a/src/mistune/__init__.py
+++ b/src/mistune/__init__.py
@@ -10,7 +10,10 @@
 
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from .block_parser import BlockParser
 from .core import BaseRenderer, BlockState, InlineState

--- a/src/mistune/core.py
+++ b/src/mistune/core.py
@@ -18,7 +18,11 @@ from typing import (
     Union,
     cast,
 )
-from typing_extensions import Self
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
 
 _LINE_END = re.compile(r'\n|$')
 

--- a/src/mistune/inline_parser.py
+++ b/src/mistune/inline_parser.py
@@ -15,7 +15,10 @@ from typing import (
     Union,
 )
 
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from .core import InlineState, Parser
 from .helpers import (

--- a/src/mistune/list_parser.py
+++ b/src/mistune/list_parser.py
@@ -3,7 +3,10 @@
 import re
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Match
 
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from .util import expand_leading_tab, expand_tab, strip_end
 

--- a/src/mistune/renderers/html.py
+++ b/src/mistune/renderers/html.py
@@ -1,6 +1,9 @@
 from typing import Any, ClassVar, Dict, Optional, Tuple
 
-from typing_extensions import Literal
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 from ..core import BaseRenderer, BlockState
 from ..util import escape as escape_text


### PR DESCRIPTION
This PR does two things:

 - add a `[project.scripts]` section to `pyproject.toml` pointing to the existing `cli` method. The cli method is made available as a runnable script named `mistune` when the project is installed (which is just syntactic sugar for `python -m mistune`). This makes it easier to use with tools like pipx that expect an executable (see: https://pipx.pypa.io/latest/how-pipx-works/#developing-for-pipx)
 
 - makes `typing_extensions` import optional based on python version being installed to (see https://typing-extensions.readthedocs.io/en/latest/#python-version-support)