### PR TITLE
fix list parsing edge case

### DIFF
--- a/src/mistune/block_parser.py
+++ b/src/mistune/block_parser.py
@@ -27,7 +27,7 @@ _BLOCK_QUOTE_LEADING = re.compile(r'^ *>', flags=re.M)
 _LINE_BLANK_END = re.compile(r'\n[ \t]*\n$')
 _BLANK_TO_LINE = re.compile(r'[ \t]*\n')
 
-_BLOCK_TAGS_PATTERN = '|'.join(BLOCK_TAGS) + '|' + '|'.join(PRE_TAGS)
+_BLOCK_TAGS_PATTERN = '(' + '|'.join(BLOCK_TAGS) + '|' + '|'.join(PRE_TAGS) + ')'
 _OPEN_TAG_END = re.compile(HTML_ATTRIBUTES + r'[ \t]*>[ \t]*(?:\n|$)')
 _CLOSE_TAG_END = re.compile(r'[ \t]*>[ \t]*(?:\n|$)')
 _STRICT_BLOCK_QUOTE = re.compile(r'( {0,3}>[^\n]*(?:\n|$))+')

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -103,3 +103,9 @@ class TestMiscCases(TestCase):
         result = md('\u2003\u2003foo\nbar\n\n\u2003\u2003foobar')
         expected = '<p>\u2003\u2003foo<br />\nbar</p>\n<p>\u2003\u2003foobar</p>'
         self.assertEqual(result.strip(), expected)
+
+    def test_html_tag_text_following_list(self):
+        md = mistune.create_markdown(escape=False, hard_wrap=True)
+        result = md('foo\n- bar\n\ntable')
+        expected = '<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>table</p>'
+        self.assertEqual(result.strip(), expected)


### PR DESCRIPTION
Fix an incorrect list parsing (text merged) in situation like:

```
foo
- bar

table
```

which output:

```
<p>foo<br />
table</p>
<ul>
<li>bar</li>
</ul>
```

instead of:

```
<p>foo</p>
<ul>
<li>bar</li>
</ul>
<p>table</p>
```

The "table" is wrongly matched by `BLOCK_HTML` specification due to the use of `_BLOCK_TAGS_PATTERN` without parens.

All text begins with what's in `BLOCK_TAGS` will have this issue.