### PR TITLE
Add block_quote prefix on empty lines too

### DIFF
--- a/src/mistune/renderers/markdown.py
+++ b/src/mistune/renderers/markdown.py
@@ -115,6 +115,7 @@ class MarkdownRenderer(BaseRenderer):
 
     def block_quote(self, token: Dict[str, Any], state: BlockState) -> str:
         text = indent(self.render_children(token, state), '> ', lambda _: True)
+        text = text.rstrip("> \n")
         return text + '\n\n'
 
     def block_html(self, token: Dict[str, Any], state: BlockState) -> str:

--- a/src/mistune/renderers/markdown.py
+++ b/src/mistune/renderers/markdown.py
@@ -114,7 +114,7 @@ class MarkdownRenderer(BaseRenderer):
         return marker2 + info + "\n" + code + marker2 + "\n\n"
 
     def block_quote(self, token: Dict[str, Any], state: BlockState) -> str:
-        text = indent(self.render_children(token, state), '> ')
+        text = indent(self.render_children(token, state), '> ', lambda _: True)
         return text + '\n\n'
 
     def block_html(self, token: Dict[str, Any], state: BlockState) -> str:

--- a/tests/fixtures/renderer_markdown.txt
+++ b/tests/fixtures/renderer_markdown.txt
@@ -228,6 +228,18 @@ hello
 > quote
 ````````````````````````````````
 
+> quote
+
+> quote
+> 
+> continuation
+.
+> quote
+
+> quote
+> 
+> continuation
+
 ## list
 
 ```````````````````````````````` example


### PR DESCRIPTION
I notice that when a blockquote has an empty line it wouldn't be rendered properly, as it would be broken in two blockquotes, from:

```
> abc
> 
> abc
```

to 


```
> abc

> abc
```

Which are rendered differently in html:
> abc
> 
> abc

and:

> abc

> abc