### PR TITLE
Fix premature HTML-escaping of inline code

### DIFF
--- a/src/mistune/inline_parser.py
+++ b/src/mistune/inline_parser.py
@@ -19,7 +19,7 @@ from .helpers import (
     parse_link_text,
     unescape_char,
 )
-from .util import escape, escape_url, unikey
+from .util import escape_url, unikey
 
 PAREN_END_RE = re.compile(r'\s*\)')
 
@@ -310,7 +310,7 @@ class InlineParser(Parser[InlineState]):
             if len(code.strip()):
                 if code.startswith(' ') and code.endswith(' '):
                     code = code[1:-1]
-            state.append_token({'type': 'codespan', 'raw': escape(code)})
+            state.append_token({'type': 'codespan', 'raw': code})
             return end_pos
         else:
             state.append_token({'type': 'text', 'raw': marker})

--- a/src/mistune/renderers/html.py
+++ b/src/mistune/renderers/html.py
@@ -91,7 +91,7 @@ class HTMLRenderer(BaseRenderer):
         return s + ' />'
 
     def codespan(self, text: str) -> str:
-        return '<code>' + text + '</code>'
+        return '<code>' + escape_text(text) + '</code>'
 
     def linebreak(self) -> str:
         return '<br />\n'

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -77,7 +77,7 @@ class TestMiscCases(TestCase):
 
     def test_ast_output(self):
         md = mistune.create_markdown(escape=False, renderer=None)
-        text = '# h1\n\nfoo **bar**'
+        text = '# h1\n\nfoo **bar**\n\n`&<>"`'
         result = md(text)
         expected = [
             {
@@ -92,6 +92,13 @@ class TestMiscCases(TestCase):
                 'children': [
                     {'type': 'text', 'raw': 'foo '},
                     {'type': 'strong', 'children': [{'type': 'text', 'raw': 'bar'}]}
+                ]
+            },
+            {'type': 'blank_line'},
+            {
+                'type': 'paragraph',
+                'children': [
+                    {'type': 'codespan', 'raw': '&<>"'},
                 ]
             },
         ]


### PR DESCRIPTION
Fixes #372 by moving HTML-escaping of `codespan` from the parser into the HTML renderer.

Passes all tests, and `test_ast_output` is enhanced to cover this case. (I just ran `pytest`, are there other tests or any linters I should run?)

**Before** (parse to AST wrongly shows raw codespan content as `&amp;`, which is a **bug** for use-cases that never render to HTML - for comparison, `&` outside of codespan doesn't get escaped):

```python
>>> import mistune
>>> md = mistune.Markdown()
>>> md('`&`')
[{'type': 'paragraph', 'children': [{'type': 'codespan', 'raw': '&amp;'}]}]
```

**After** (pure parse correctly shows raw code content is `&`):

```python
>>> import mistune
>>> md = mistune.Markdown()
>>> md('`&`')
[{'type': 'paragraph', 'children': [{'type': 'codespan', 'raw': '&'}]}]
```

After (still works when rendering to HTML):

```python
>>> md.renderer = mistune.HTMLRenderer()
>>> md('`&`')
'<p><code>&amp;</code></p>\n'
```

**Use-case example**: I have a script which publishes files written in Markdown as Tumblr posts. It walks through Mistune's AST, generating Tumblr's "NPF". I need the raw contents, because Tumblr takes the raw text and does its own HTML rendering+escaping server-side. Currently, my script has to have extra handling for `codespan` tokens to unescape the characters escaped by `mistune.util.escape`.

P.S. Special thanks to @torokati44 for finding the exact line in the parser that was causing the problem.