### PR TITLE
Fix premature (and incomplete) HTML-escaping of links

### DIFF
--- a/src/mistune/directives/image.py
+++ b/src/mistune/directives/image.py
@@ -64,7 +64,7 @@ def render_block_image(
     height: Optional[str] = None,
     **attrs: Any,
 ) -> str:
-    img = '<img src="' + src + '"'
+    img = '<img src="' + escape_text(src) + '"'
     style = ''
     if alt:
         img += ' alt="' + escape_text(alt) + '"'
@@ -90,7 +90,7 @@ def render_block_image(
 
     target = attrs.get('target')
     if target:
-        href = escape_text(self.safe_url(target))
+        href = self.safe_url(target)
         outer = '<a class="' + _cls + '" href="' + href + '">'
         return outer + img + '</a>\n'
     else:

--- a/src/mistune/renderers/html.py
+++ b/src/mistune/renderers/html.py
@@ -53,17 +53,17 @@ class HTMLRenderer(BaseRenderer):
         links, images, and etc.
         """
         if self._allow_harmful_protocols is True:
-            return url
+            return escape_text(url)
 
         _url = url.lower()
         if self._allow_harmful_protocols and \
             _url.startswith(tuple(self._allow_harmful_protocols)):
-            return url
+            return escape_text(url)
 
         if _url.startswith(self.HARMFUL_PROTOCOLS) and \
             not _url.startswith(self.GOOD_DATA_PROTOCOLS):
             return '#harmful-link'
-        return url
+        return escape_text(url)
 
     def text(self, text: str) -> str:
         if self._escape:

--- a/src/mistune/util.py
+++ b/src/mistune/util.py
@@ -36,7 +36,7 @@ def escape_url(link: str) -> str:
         '!$&()*+,;='      # sub-delims - "'" (rfc3986)
         '%'               # leave already-encoded octets alone
     )
-    return escape(quote(unescape(link), safe=safe))
+    return quote(unescape(link), safe=safe)
 
 
 def safe_entity(s: str) -> str:

--- a/tests/fixtures/fenced_image.txt
+++ b/tests/fixtures/fenced_image.txt
@@ -81,3 +81,22 @@
 .
 <a class="block-image align-left" href="https://lepture.com"><img src="picture.png" alt="description" width="100" height="50" /></a>
 ````````````````````````````````
+
+## ampersand in source
+
+```````````````````````````````` example
+~~~{image} https://example.com/picture.png?foo=qux&test=me
+~~~
+.
+<div class="block-image"><img src="https://example.com/picture.png?foo=qux&amp;test=me" /></div>
+````````````````````````````````
+
+## ampersand in target
+
+```````````````````````````````` example
+~~~{image} picture.png
+:target: https://example.com/rickroll?a=1&b=2
+~~~
+.
+<a class="block-image" href="https://example.com/rickroll?a=1&amp;b=2"><img src="picture.png" /></a>
+````````````````````````````````

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -97,6 +97,25 @@ class TestMiscCases(TestCase):
         ]
         self.assertEqual(result, expected)
 
+    def test_ast_url(self):
+        md = mistune.create_markdown(escape=False, renderer=None)
+        label = 'hi &<>"'
+        url = 'https://example.com/foo?a=1&b=2'
+        text = '[{}]({})'.format(label, url)
+        result = md(text)
+        expected = [
+            {
+                'type': 'paragraph',
+                'children': [
+                    {
+                        'type': 'link',
+                        'children': [{'type': 'text', 'raw': label}],
+                        'attrs': {'url': url},
+                    },
+                ],
+            },
+        ]
+        self.assertEqual(result, expected)
 
     def test_emsp(self):
         md = mistune.create_markdown(escape=False, hard_wrap=True)


### PR DESCRIPTION
This fixes three bugs:

1. links were being prematurely HTML-escaped (when being parsed into AST instead of waiting until rendering to HTML) ( #394 )
2. image directive was double-escaping `target` links, and
3. image directive wasn't escaping `src` links at all.

Same idea as the fix in #393 - move the HTML-escaping out of the parse and into the *rendering*.

Tests updated to catch all three bugs.

You can merge this and #393 in any order (no merge conflicts either way).