### PR TITLE
docs: add a mistune-telegram extension

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -2,3 +2,5 @@ Community Extensions
 ====================
 
 Here is the list of plugins and directives created by the community.
+
+* `mistune-telegram <https://github.com/impocode/mistune-telegram>`_ - Plugin mistune for converting Markdown into Telegram format.


### PR DESCRIPTION
Hello!

Now I am actively working on [mistune-telegram](https://github.com/impocode/mistune-telegram). It is an extension that allows to convert Markdown to [Telegram format](https://core.telegram.org/bots/api#formatting-options).