### PR TITLE
fix: change attribute name from markdown to md in the Plugin class

### DIFF
--- a/src/mistune/plugins/__init__.py
+++ b/src/mistune/plugins/__init__.py
@@ -24,7 +24,7 @@ _plugins = {
 
 
 class Plugin(Protocol):
-    def __call__(self, markdown: "Markdown") -> None: ...
+    def __call__(self, md: "Markdown") -> None: ...
 
 _cached_modules: Dict[str, Plugin] = {}
 


### PR DESCRIPTION
Hello! My linter shows a warning like this due to incorrect naming.

![image_2025-01-09_15-53-22](https://github.com/user-attachments/assets/fa107c0d-e2b1-4f96-bf45-6def5ad80c31)

```python
import mistune
from mistune.plugins.formatting import strikethrough

from mistune_telegram import TelegramMarkdownV2Renderer

formater = mistune.create_markdown(renderer=TelegramMarkdownV2Renderer(), plugins=[strikethrough])
```