### PR TITLE
Stop generators causing invalid output from render_toc_ul

### DIFF
--- a/src/mistune/toc.py
+++ b/src/mistune/toc.py
@@ -83,6 +83,9 @@ def render_toc_ul(toc: Iterable[Tuple[int, str, str]]) -> str:
           (1, 'toc-license', 'License'),
         ]
     """
+    toc = tuple(toc)  # if toc is a generator (eg. from filter or map), the
+    # below check will always return true, even in cases such as filter(fn, [])
+    # causing render_toc_ul to output invalid data
     if not toc:
         return ''
 


### PR DESCRIPTION
This PR fixes the following behaviour:

```python
>> from mistune.toc import render_toc_ul
>>> render_toc_ul([])
''
>>> render_toc_ul(filter(lambda _: False, []))
'<ul>\n</li>\n</ul>\n'
```
