### PR TITLE
Optimize rule registration with a set for faster lookups

### DIFF
--- a/src/mistune/core.py
+++ b/src/mistune/core.py
@@ -151,6 +151,7 @@ class Parser(Generic[ST]):
     def __init__(self) -> None:
         self.specification = self.SPECIFICATION.copy()
         self.rules = list(self.DEFAULT_RULES)
+        self.rules_set = set(self.DEFAULT_RULES)
         self._methods: Dict[
             str,
             Callable[[Match[str], ST], Optional[int]],
@@ -192,7 +193,8 @@ class Parser(Generic[ST]):
         self._methods[name] = lambda m, state: func(self, m, state)
         if pattern:
             self.specification[name] = pattern
-        if name not in self.rules:
+        if name not in self.rules_set:
+            self.rules_set.add(name)
             self.insert_rule(self.rules, name, before=before)
 
     def register_rule(self, name: str, pattern: str, func: Any) -> None:


### PR DESCRIPTION
## Overview
This PR introduces a small but meaningful optimization to the `Parser` class in `mistune/core.py`. The change involves adding a `rules_set` (a Python `set`) alongside the existing `rules` list to improve the performance of rule lookups during registration. While the time difference might not be drastic in most cases, this refactoring makes the code more efficient and aligns with best practices for membership testing.

## What Changed?
- Added `self.rules_set = set(self.DEFAULT_RULES)` in the `__init__` method to initialize a set-based version of the rules.
- Updated the `register` method to use `self.rules_set` for checking if a rule name already exists (`if name not in self.rules_set`) instead of relying on the `self.rules` list.
- When a new rule is registered, it’s added to `rules_set` via `self.rules_set.add(name)` before being inserted into the `rules` list.

The core logic of the code remains unchanged—rules are still stored in the `rules` list and inserted in the same order as before. The `rules_set` is simply an additional data structure to optimize lookups.

## Why Use a Set?
In Python, checking membership (`in`) in a list has a time complexity of **O(n)**, as it requires a linear scan of the list. In contrast, a `set` offers **O(1)** average-case time complexity for membership tests due to its hash-based implementation. By introducing `rules_set`, we reduce the cost of verifying whether a rule already exists from O(n) to O(1), which is particularly beneficial as the number of rules grows.

While the performance gain might not be noticeable in small-scale use cases, this change:
1. **Scales better**: As the rule set expands, the O(1) lookup time ensures consistent performance.
2. **Improves readability**: It makes the intent clear—`rules_set` is explicitly for fast lookups, while `rules` retains the ordered sequence.
3. **Follows Pythonic principles**: Leveraging `set` for membership testing is a well-established idiom in Python.

## No Logic Changes
This is purely an optimization. The behavior of the `Parser` class—how rules are stored, ordered, and processed—remains identical. The `rules` list still governs the insertion order and rule execution, while `rules_set` is only used for the `in` check. 