### PR TITLE
feat: Support footnotes that start on the next line.

### DIFF
--- a/src/mistune/plugins/footnotes.py
+++ b/src/mistune/plugins/footnotes.py
@@ -70,8 +70,11 @@ def parse_footnote_item(block: "BlockParser", key: str, index: int, state: Block
         spaces = len(second_line) - len(second_line.lstrip())
         pattern = re.compile(r"^ {" + str(spaces) + r",}", flags=re.M)
         text = pattern.sub("", text).strip()
-        items = _PARAGRAPH_SPLIT.split(text)
-        children = [{"type": "paragraph", "text": s} for s in items]
+
+        footer_state = BlockState()
+        footer_state.process(text)
+        block.parse(footer_state)
+        children = footer_state.tokens
     else:
         text = text.strip()
         children = [{"type": "paragraph", "text": text}]

--- a/tests/fixtures/footnotes.txt
+++ b/tests/fixtures/footnotes.txt
@@ -70,3 +70,28 @@ non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.<a h
 </ol>
 </section>
 ````````````````````````````````
+
+```````````````````````````````` example
+fenced code block in footnote[^1]
+
+[^1]:
+    first
+
+    ```sh
+    second
+    third
+    ```
+
+    fourth
+.
+<p>fenced code block in footnote<sup class="footnote-ref" id="fnref-1"><a href="#fn-1">1</a></sup></p>
+<section class="footnotes">
+<ol>
+<li id="fn-1"><p>first</p>
+<pre><code class="language-sh">second
+third
+</code></pre>
+<p>fourth<a href="#fnref-1" class="footnote">&#8617;</a></p></li>
+</ol>
+</section>
+````````````````````````````````


### PR DESCRIPTION
When footnotes get too long, prettier will format them to begin on the next line, with an indentation level of 4. This can be reproduced by formatting with `prettier --prose-wrap=always`. The current parser does not accurately parse this use case. Should resolve #373 