### PR TITLE
fix: handle escaped dollar signs in inline math

### DIFF
--- a/src/mistune/plugins/math.py
+++ b/src/mistune/plugins/math.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 __all__ = ["math", "math_in_quote", "math_in_list"]
 
 BLOCK_MATH_PATTERN = r"^ {0,3}\$\$[ \t]*\n(?P<math_text>[\s\S]+?)\n\$\$[ \t]*$"
-INLINE_MATH_PATTERN = r"\$(?!\s)(?P<math_text>.+?)(?!\s)\$"
+INLINE_MATH_PATTERN = r"\$(?!\s)(?P<math_text>(?:[^$\\]|\\.)+?)(?!\s)\$"
 
 
 def parse_block_math(block: "BlockParser", m: Match[str], state: "BlockState") -> int:

--- a/tests/fixtures/math.txt
+++ b/tests/fixtures/math.txt
@@ -55,3 +55,9 @@ with $a\neq b$ such that $f(a)=f(b)$.
 singleton set <span class="math">\(e_G\)</span>, because otherwise <span class="math">\(\exists a,b\in G\)</span>
 with <span class="math">\(a\neq b\)</span> such that <span class="math">\(f(a)=f(b)\)</span>.</p>
 ````````````````````````````````
+
+```````````````````````````````` example
+Escaped dollar sign in math: $x=\$$
+.
+<p>Escaped dollar sign in math: <span class="math">\(x=\$\)</span></p>
+````````````````````````````````


### PR DESCRIPTION
## Bug
[Issue #370](https://github.com/lepture/mistune/issues/370) — Escaped `$` in inline math expressions are incorrectly parsed, causing the math expression to be split at the escaped dollar sign.

## Problem
The current inline math pattern `r"$(?!\s)(?P<math_text>.+?)(?!\s)$"` uses a simple non-greedy match that doesn't handle escaped characters. For input like `$x=\$$`, it incorrectly parses as:
- Math content: `x=\`
- Text content: `$`

## Solution
Updated the pattern to `r"$(?!\s)(?P<math_text>(?:[^$\\]|\\.)+?)(?!\s)$"` which:
- Matches non-dollar, non-backslash characters: `[^$\\]`
- Matches escaped sequences: `\\.`
- Ensures escaped `\$` characters are treated as literal content within math expressions

## Testing
- Added test case for escaped dollar signs in math expressions
- All existing math tests continue to pass
- Verified the fix handles `$x=\$$` correctly as a single math expression `x=\$`

Greetings, saschabuehrle