### PR TITLE
♻️ Refactor: Missing UTF-8 encoding in file open

### DIFF
--- a/benchmark/bench.py
+++ b/benchmark/bench.py
@@ -14,7 +14,7 @@ def load_case(filename):
         filepath = os.path.join(ROOT_DIR, "../README.md")
     else:
         filepath = os.path.join(ROOT_DIR, "cases", filename)
-    with open(filepath, "r") as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         content = f.read()
 
     name = filename.replace(".txt", "")


### PR DESCRIPTION
## ♻️ Refactoring

### Problem
The `open(filepath, "r")` call does not specify an encoding. In Python, this defaults to the system's default encoding (e.g., `cp1252` on Windows). If the Markdown files contain emojis or other non-ASCII characters, this will raise a `UnicodeDecodeError` on those platforms.


**Severity**: `medium`
**File**: `benchmark/bench.py`

### Solution
Explicitly specify the encoding by changing the line to: `with open(filepath, "r", encoding="utf-8") as f:`


### Changes
- `benchmark/bench.py` (modified)

### Testing
- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>
