### PR TITLE
fix: remove double-encoding of image alt text

### DIFF
--- a/src/mistune/renderers/html.py
+++ b/src/mistune/renderers/html.py
@@ -80,7 +80,7 @@ class HTMLRenderer(BaseRenderer):
 
     def image(self, text: str, url: str, title: Optional[str] = None) -> str:
         src = self.safe_url(url)
-        alt = escape_text(striptags(text))
+        alt = striptags(text)
         s = '<img src="' + src + '" alt="' + alt + '"'
         if title:
             s += ' title="' + safe_entity(title) + '"'

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -136,6 +136,19 @@ class TestMiscCases(TestCase):
         expected = "<h1>\u3000\u3000abc</h1>\n"
         self.assertEqual(result, expected)
 
+    def test_image_alt_no_double_encoding(self):
+        result = mistune.html("![dogs & cats](dogs.png)")
+        expected = '<p><img src="dogs.png" alt="dogs &amp; cats" /></p>'
+        self.assertEqual(result.strip(), expected)
+
+        result = mistune.html("![dogs > cats](dogs.png)")
+        expected = '<p><img src="dogs.png" alt="dogs &gt; cats" /></p>'
+        self.assertEqual(result.strip(), expected)
+
+        result = mistune.html('!["quoted"](dogs.png)')
+        expected = '<p><img src="dogs.png" alt="&quot;quoted&quot;" /></p>'
+        self.assertEqual(result.strip(), expected)
+
     def test_html_tag_text_following_list(self):
         md = mistune.create_markdown(escape=False, hard_wrap=True)
         result = md("foo\n- bar\n\ntable")


### PR DESCRIPTION
Fixes #432

## Problem

Image alt attributes are double-encoded. For example:

```python
>>> mistune.html("![dogs & cats](dogs.png)")
'<p><img src="dogs.png" alt="dogs &amp;amp; cats" /></p>\n'
#                                    ^^^^^^^^^ should be &amp;
```

## Cause

In `HTMLRenderer.image()`, the `text` parameter arrives already HTML-escaped from the rendering pipeline (`render_tokens` → `text()` → `escape_text()`). Calling `escape_text(striptags(text))` escapes entities a second time.

## Fix

Remove the redundant `escape_text()` call. `striptags()` only strips HTML tags and preserves existing entities, so its output is already safe for use in an HTML attribute.

## Before / After

| Input | Before | After |
|-------|--------|-------|
| `![dogs & cats](d.png)` | `alt="dogs &amp;amp; cats"` | `alt="dogs &amp; cats"` |
| `![dogs > cats](d.png)` | `alt="dogs &amp;gt; cats"` | `alt="dogs &gt; cats"` |
| `!["quoted"](d.png)` | `alt="&amp;quot;quoted&amp;quot;"` | `alt="&quot;quoted&quot;"` |

## Validation

All 959 tests pass (including 596 CommonMark spec tests). A regression test is included.