### PR TITLE
fix: route image directive src through safe_url

### DIFF
--- a/src/mistune/directives/image.py
+++ b/src/mistune/directives/image.py
@@ -62,7 +62,7 @@ def render_block_image(
     height: Optional[str] = None,
     **attrs: Any,
 ) -> str:
-    img = '<img src="' + escape_text(src) + '"'
+    img = '<img src="' + self.safe_url(src) + '"'
     style = ""
     if alt:
         img += ' alt="' + escape_text(alt) + '"'

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -91,3 +91,20 @@ class TestDirectiveInclude(BaseTestCase):
         s = ".. include:: foo.txt"
         html = self.md(s)
         self.assertIn("Missing source file", html)
+
+
+class TestImageDirectiveSrc(BaseTestCase):
+    md = create_markdown(escape=False, plugins=[RSTDirective([Image()])])  # type: ignore[list-item]
+
+    def test_harmful_src_blocked(self):
+        html = self.md(".. image:: javascript:alert")
+        self.assertIn('src="#harmful-link"', html)
+        self.assertNotIn("javascript:alert", html)
+
+    def test_safe_src_preserved(self):
+        html = self.md(".. image:: cat.png")
+        self.assertIn('src="cat.png"', html)
+
+    def test_target_still_filtered(self):
+        html = self.md(".. image:: cat.png\n   :target: javascript:alert")
+        self.assertNotIn("javascript:alert", html)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -41,6 +41,34 @@ class TestMiscCases(TestCase):
         expected = '<p><a href="#harmful-link">h</a></p>'
         self.assertEqual(result.strip(), expected)
 
+    def test_harmful_links_variants(self):
+        # entity-decoded, alternate-scheme, and reference-link forms are all
+        # routed to the #harmful-link sentinel.
+        for text in [
+            "[h](javascript:alert)",
+            "[h](&#x6a;avascript:alert)",
+            "[h](javascript&colon;alert)",
+            "[h](vbscript:msgbox)",
+            "[h](file:///etc/passwd)",
+            "[h](data:text/html,xss)",
+            "[h](data:image/svg+xml,xss)",
+            "[h][r]\n\n[r]: javascript:alert",
+        ]:
+            result = mistune.html(text)
+            self.assertIn('href="#harmful-link"', result, text)
+            self.assertNotIn("javascript:alert", result, text)
+
+    def test_control_char_scheme_not_executable(self):
+        # A control char or encoded colon inside the scheme is percent-encoded
+        # by escape_url, so the rendered href is never an executable
+        # javascript: scheme (regardless of the sentinel path).
+        for text in [
+            "[h](<java\tscript:alert>)",
+            "[h](<java&#x09;script:alert>)",
+            "[h](javascript%3Aalert)",
+        ]:
+            self.assertNotIn("javascript:alert", mistune.html(text), text)
+
     def test_ref_link(self):
         result = mistune.html("[link][h]\n\n[h]: /foo")
         expected = '<p><a href="/foo">link</a></p>'


### PR DESCRIPTION
The inline image renderer (HTMLRenderer.image) routes src through safe_url, but the image/figure directive's render_block_image renders src with escape_text only. As a result `.. image:: javascript:alert` produced `<img src="javascript:alert">`, inconsistent with the inline `![alt](javascript:...)` path which yields `src="#harmful-link"`.

This is not a known exploit (javascript: in <img src> does not execute in current browsers), but the directive should match the renderer's link/image safety contract so the two paths cannot drift.

- render_block_image now calls self.safe_url(src); this is a drop-in for the previous escape_text(src) on any non-harmful scheme (safe_url returns escape_text(url) in that case) and maps harmful schemes to #harmful-link.
- Add behaviour-pinning tests for harmful/encoded/safe scheme variants across inline links, reference links, and the image directive.