### PR TITLE
Cap block quote and list nesting jointly to avoid RecursionError

### DIFF
--- a/src/mistune/block_parser.py
+++ b/src/mistune/block_parser.py
@@ -370,8 +370,14 @@ class BlockParser(Parser[BlockState]):
         # scan children state
         child = state.child_state(text)
         if state.depth() >= self.max_nested_level - 1:
-            rules = list(self.block_quote_rules)
-            rules.remove("block_quote")
+            # At the nesting limit, stop descending into any further container
+            # blocks. Trimming only "block_quote" still allowed block quotes and
+            # lists to recurse into each other without bound (RecursionError).
+            rules = [
+                rule
+                for rule in self.block_quote_rules
+                if rule not in ("block_quote", "list")
+            ]
         else:
             rules = self.block_quote_rules
 

--- a/src/mistune/list_parser.py
+++ b/src/mistune/list_parser.py
@@ -56,8 +56,12 @@ def parse_list(block: "BlockParser", m: Match[str], state: "BlockState") -> int:
     groups: Optional[tuple[str, str, str]] = (m.group("list_1"), marker, text)
 
     if depth >= block.max_nested_level - 1:
-        rules = list(block.list_rules)
-        rules.remove("list")
+        # At the nesting limit, stop descending into any further container
+        # blocks. Trimming only "list" still allowed lists and block quotes to
+        # recurse into each other without bound (RecursionError).
+        rules = [
+            rule for rule in block.list_rules if rule not in ("list", "block_quote")
+        ]
     else:
         rules = block.list_rules
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -182,3 +182,13 @@ class TestMiscCases(TestCase):
         result = md("foo\n- bar\n\ntable")
         expected = "<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>table</p>"
         self.assertEqual(result.strip(), expected)
+
+    def test_deeply_nested_block_quote_and_list(self):
+        # Block quotes and lists each capped their own nesting at the limit but
+        # not each other's, so alternating them recursed without bound. This
+        # must terminate instead of raising RecursionError.
+        text = "".join(">" * i + " " + "- " * i + "item\n" for i in range(1, 300))
+        md = mistune.create_markdown()
+        md(text)
+        ast = mistune.create_markdown(renderer="ast")
+        ast(text)


### PR DESCRIPTION
Block quotes and lists each stop descending into their **own** type once `state.depth()` hits `max_nested_level`, but they leave the **other** container's rule enabled. Markdown that alternates the two recurses without bound and raises `RecursionError`, even though pure block-quote nesting and pure list nesting are already capped.

Minimal repro:

```python
import mistune
md = mistune.create_markdown()
md("".join(">" * i + " " + "- " * i + "item\n" for i in range(1, 300)))
# RecursionError: maximum recursion depth exceeded
```

This is the cross-container counterpart to the same-type list case fixed in #356.

Fix: at the nesting limit, drop both `"block_quote"` and `"list"` from the child rules in both parsers, so all container nesting is bounded (not just nesting of the same type). Behavior for documents within the limit is unchanged.

Added a regression test; the full suite passes.
