### PR TITLE
fix(math): reject currency patterns and cross-line matches in inline math

### DIFF
--- a/src/mistune/plugins/math.py
+++ b/src/mistune/plugins/math.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 __all__ = ["math", "math_in_quote", "math_in_list"]
 
 BLOCK_MATH_PATTERN = r"^ {0,3}\$\$[ \t]*\n(?P<math_text>[\s\S]+?)\n\$\$[ \t]*$"
-INLINE_MATH_PATTERN = r"\$(?!\s)(?P<math_text>(?:[^$\\]|\\.)+?)(?!\s)\$"
+INLINE_MATH_PATTERN = r"\$(?!\$)(?!\s)(?P<math_text>(?:[^$\\\n]|\\.)+?)\$(?!\d)"
 
 
 def parse_block_math(block: "BlockParser", m: Match[str], state: "BlockState") -> int:

--- a/tests/fixtures/math.txt
+++ b/tests/fixtures/math.txt
@@ -61,3 +61,39 @@ Escaped dollar sign in math: $x=\$$
 .
 <p>Escaped dollar sign in math: <span class="math">\(x=\$\)</span></p>
 ````````````````````````````````
+
+```````````````````````````````` example
+The $n$th element is valid.
+.
+<p>The <span class="math">\(n\)</span>th element is valid.</p>
+````````````````````````````````
+
+```````````````````````````````` example
+Result is $x^2$.
+.
+<p>Result is <span class="math">\(x^2\)</span>.</p>
+````````````````````````````````
+
+## Currency rejection
+
+```````````````````````````````` example
+Price is $51,300 and cost is $51,300 total.
+.
+<p>Price is $51,300 and cost is $51,300 total.</p>
+````````````````````````````````
+
+```````````````````````````````` example
+The $1.6T valuation narrative.
+.
+<p>The $1.6T valuation narrative.</p>
+````````````````````````````````
+
+## Cross-line rejection
+
+```````````````````````````````` example
+Line one $500
+Line two $600
+.
+<p>Line one $500
+Line two $600</p>
+````````````````````````````````


### PR DESCRIPTION
## Summary

Mistune's `INLINE_MATH_PATTERN` has bugs that cause false-positive inline math detection on currency values like `$51,300`. This PR fixes them directly in the upstream regex.

## Root Cause

Three issues in the current regex `\$(?!\s)(?P<math_text>(?:[^$\\]|\\.)+?)(?!\s)\$`:

1. **Broken lookahead**: The second `(?!\s)` checks the closing `$` delimiter (which is never whitespace), not the preceding content character. It's a no-op.
2. **Cross-line matching**: `[^$\\]` allows newlines, so `$` signs on different lines can pair as math delimiters.
3. **No digit boundary**: Closing `$` followed by a digit (e.g. `$51,300`) is accepted, matching currency as math.

Additionally, no `(?!\$)` guard prevents partial matching of `$$` block delimiters as inline math.

## Fix

New pattern: `\$(?!\$)(?!\s)(?P<math_text>(?:[^$\\\n]|\\.)+?)\$(?!\d)`

Changes:
- `(?!\$)`: reject `$$` block delimiter starts
- `[^$\\\n]`: disallow newlines in inline math (single-line only)
- `(?!\d)`: closing `$` cannot precede a digit (GFM-compatible, rejects currency)
- Remove broken `(?!\s)` before closing `$` (was always a no-op)

## Tests

New fixture test cases added covering:
- Valid math: `$x^2$`, `$n$th`, trailing punctuation
- Currency rejection: `$51,300` pairs, single `$1.6T`
- Cross-line rejection

All 978 existing tests pass with no regressions.

## Credit

Bug identified via [geopanther/mdfluence#70](https://github.com/geopanther/mdfluence/pull/70).
