### PR TITLE
Fix MarkdownRenderer re-rendering of code spans containing backticks

### DIFF
--- a/src/mistune/renderers/markdown.py
+++ b/src/mistune/renderers/markdown.py
@@ -7,6 +7,7 @@ from ..util import strip_end
 from ._list import render_list
 
 fenced_re = re.compile(r"^[`~]+", re.M)
+_backtick_run_re = re.compile(r"`+")
 
 #: leading markers that would be parsed as a new block (list, heading, block
 #: quote) if they appear unescaped at the start of a line.
@@ -77,7 +78,16 @@ class MarkdownRenderer(BaseRenderer):
         return "!" + self.link(token, state)
 
     def codespan(self, token: Dict[str, Any], state: BlockState) -> str:
-        return "`" + cast(str, token["raw"]) + "`"
+        code = cast(str, token["raw"])
+        # The delimiter must be a run of backticks longer than any backtick run
+        # inside the content, otherwise the content would close the span early.
+        longest = max((len(run) for run in _backtick_run_re.findall(code)), default=0)
+        fence = "`" * (longest + 1)
+        # A space on each side keeps the delimiter from merging with a leading or
+        # trailing backtick; the parser strips this padding back off.
+        if code.startswith("`") or code.endswith("`"):
+            return fence + " " + code + " " + fence
+        return fence + code + fence
 
     def linebreak(self, token: Dict[str, Any], state: BlockState) -> str:
         return "  \n"

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -46,6 +46,18 @@ class TestMarkdownRendererRoundTrip(TestCase):
     def test_escaped_backtick(self):
         self.assert_round_trip(r"\`not code\`" + "\n")
 
+    def test_codespan_containing_backticks(self):
+        # the delimiter must grow past any backtick run inside the code span,
+        # and pad away a leading/trailing backtick, or the re-parse breaks
+        for text in (
+            "``a single ` backtick``\n",
+            "``` two `` backticks ```\n",
+            "`` `leading backtick``\n",
+            "``trailing backtick` ``\n",
+            "`` `surrounded` ``\n",
+        ):
+            self.assert_round_trip(text)
+
     def test_real_markers_preserved(self):
         for text in (
             "* bullet\n",


### PR DESCRIPTION
### Problem

`MarkdownRenderer.codespan` always wraps the content in a single backtick pair:

```python
return "`" + token["raw"] + "`"
```

When the code-span content itself contains backticks, re-rendering the AST produces Markdown that no longer round-trips:

- an inner backtick closes the span early, and
- a code span whose raw content is a single `` ` `` renders as ```` ``` ```` , which re-parses as an empty fenced **code block**.

This shows up through mistune's own round-trip oracle (`to_html(text)` vs `to_html(reformat(text))`):

```python
from mistune import create_markdown
from mistune.renderers.markdown import MarkdownRenderer

to_html = create_markdown(escape=False)
reformat = create_markdown(renderer=MarkdownRenderer())

src = "``code with ` inside``\n"
assert to_html(reformat(src)) == to_html(src)  # fails on main
```

### Fix

Size the delimiter to one more than the longest backtick run inside the content, and add one space of padding on each side when the content begins or ends with a backtick. That matches both CommonMark and mistune's own `parse_codespan`, which strips a single surrounding space back off (`inline_parser.py`: `if code.startswith(" ") and code.endswith(" "): code = code[1:-1]`).

For content with no backticks the delimiter stays a single backtick, so output is byte-for-byte identical to before; only backtick-containing spans change.

### Tests

Added `test_codespan_containing_backticks` to `TestMarkdownRendererRoundTrip`, exercising single/double inner backticks plus leading, trailing, and surrounding backticks through the existing `assert_round_trip` helper. It fails before the change and passes after. Full suite: 985 passed; `ruff check`, `ruff format`, and `mypy` all clean.

I used an AI assistant to help investigate this under my direction, and I have reviewed and verified the change myself.
