### PR TITLE
Preserve task-list checkbox in markdown and rst renderers

### DIFF
--- a/src/mistune/renderers/_list.py
+++ b/src/mistune/renderers/_list.py
@@ -30,6 +30,13 @@ def _render_list_item(
 ) -> str:
     leading = cast(str, parent["leading"])
     text = ""
+    # The task_lists plugin rewrites a list_item into a task_list_item and
+    # moves the "[ ] "/"[x] " marker into attrs. Unlike the html renderer, the
+    # markdown and rst renderers render list items here rather than through a
+    # per-token method, so re-emit the checkbox to keep it from being silently
+    # dropped on round-trip.
+    if item["type"] == "task_list_item":
+        text = "[x] " if item["attrs"]["checked"] else "[ ] "
     for tok in item["children"]:
         if tok["type"] == "list":
             tok["parent"] = parent

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -65,3 +65,41 @@ class TestMarkdownRendererRoundTrip(TestCase):
             "ratio a/b is fine\n",
         ):
             self.assert_round_trip(text)
+
+
+class TestTaskListRoundTrip(TestCase):
+    """The task_lists plugin rewrites a list_item into a task_list_item and
+    moves the checkbox marker into attrs. The markdown and rst renderers must
+    re-emit it instead of silently dropping it (issues #401 and #441)."""
+
+    to_html = create_markdown(escape=False, plugins=["task_lists"])
+    reformat = create_markdown(renderer=MarkdownRenderer(), plugins=["task_lists"])
+    to_rst = create_markdown(renderer=RSTRenderer(), plugins=["task_lists"])
+
+    def assert_round_trip(self, text):
+        self.assertEqual(
+            self.to_html(self.reformat(text)),
+            self.to_html(text),
+        )
+
+    def test_checkbox_preserved(self):
+        # the exact issue example: the checkbox used to disappear entirely
+        self.assertEqual(
+            self.reformat("- [x] done\n- [ ] todo\n"),
+            "- [x] done\n- [ ] todo\n",
+        )
+
+    def test_round_trip_variants(self):
+        for text in (
+            "- [x] done\n- [ ] todo\n",
+            "- [X] upper-x is checked\n",
+            "1. [ ] a\n2. [x] b\n",
+            "- [ ] outer\n  - [x] inner\n",
+            "- [ ] line one\n  line two\n",
+            "- plain item\n- [ ] task item\n",
+        ):
+            self.assert_round_trip(text)
+
+    def test_rst_preserves_checkbox(self):
+        self.assertIn("[x] done", self.to_rst("- [x] done\n"))
+        self.assertIn("[ ] todo", self.to_rst("- [ ] todo\n"))


### PR DESCRIPTION
## Problem

With the `task_lists` plugin enabled, the `MarkdownRenderer` (and `RSTRenderer`) silently drop the `[ ]`/`[x]` checkbox, so re-formatting Markdown loses information:

```python
import mistune
from mistune.renderers.markdown import MarkdownRenderer

reformat = mistune.create_markdown(renderer=MarkdownRenderer(), plugins=["task_lists"])
print(reformat("- [x] done\n- [ ] todo\n"))
```
```
- done
- todo
```

The checkbox is gone, so the output no longer parses as a task list.

## Root cause

`task_lists` rewrites each `list_item` into a `task_list_item` token and moves the marker into `attrs["checked"]`. It then registers a render method **only** for the html renderer:

```python
if md.renderer and md.renderer.NAME == "html":
    md.renderer.register("task_list_item", render_task_list_item)
```

The html renderer dispatches every list item through `render_token`, so that registered method runs. The markdown and rst renderers instead render list items through the shared `renderers/_list.py:_render_list_item` helper, which renders only the item's *children* and never dispatches the `task_list_item` type. The checkbox therefore has nowhere to be emitted and is discarded.

## Fix

Re-emit the marker for `task_list_item` tokens in `_render_list_item` (the same helper already special-cases the `list` and `blank_line` types). Now `- [x] done` round-trips to `- [x] done`.

## Tests

Added `TestTaskListRoundTrip` in `tests/test_renderers.py`, following the existing `TestMarkdownRendererRoundTrip` pattern (`to_html(reformat(text)) == to_html(text)`), covering checked/unchecked, `[X]`, ordered, nested, multiline and mixed plain/task lists, plus an rst assertion. All three fail on `main` and pass with the fix.

`mypy --strict src`, `mypy src tests`, `ruff check` and the full `pytest` suite (638 passed) are green locally.

Fixes #441
Fixes #401