### PR TITLE
Fix overzealous html decoding in mistune 2.x

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,15 +16,20 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
     strategy:
       fail-fast: false
       max-parallel: 6
       matrix:
         python: ["2.7", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        include:
+          - {python: "2.7", image: "python:2.7"}
+          - {python: "3.7", image: "python:3.7"}
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}
+      if: ${{ matrix.image == null }}
       uses: actions/setup-python@v2.1.4
       with:
         python-version: ${{ matrix.python }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -41,9 +41,6 @@ jobs:
         pip install pytest pytest-cov
 
     - name: Test with Python ${{ matrix.python }}
-      run: pytest
-
-    - name: Report coverage
       run: pytest --cov=mistune --cov-report=xml
 
     - name: Upload coverage to Codecov

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        python: ["2.7", "3.7", "3.8", "3.9", "3.10", "pypy3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.11"]
         include:
           - {python: "2.7", image: "python:2.7"}
           - {python: "3.7", image: "python:3.7"}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,16 +21,17 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        python: ["2.7", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python: ["2.7", "3.7", "3.8", "3.9", "3.10", "pypy3.11"]
         include:
           - {python: "2.7", image: "python:2.7"}
           - {python: "3.7", image: "python:3.7"}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
     - name: Set up Python ${{ matrix.python }}
       if: ${{ matrix.image == null }}
-      uses: actions/setup-python@v2.1.4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python }}
 
@@ -46,9 +47,9 @@ jobs:
       run: pytest --cov=mistune --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.14
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: GitHub

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,12 +20,11 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["2.7", "3.7", "3.8", "3.9", "3.10", "pypy3"]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python }} on ${{ matrix.os }}
+    - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v2.1.4
       with:
         python-version: ${{ matrix.python }}
@@ -35,7 +34,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest pytest-cov
 
-    - name: Test with Python ${{ matrix.python }} on ${{ matrix.os }}
+    - name: Test with Python ${{ matrix.python }}
       run: pytest
 
     - name: Report coverage

--- a/mistune/util.py
+++ b/mistune/util.py
@@ -1,3 +1,4 @@
+import re
 try:
     from urllib.parse import quote
     import html
@@ -28,14 +29,40 @@ def escape_url(link):
 
     if html is None:
         return quote(link.encode('utf-8'), safe=safe)
-    return html.escape(quote(html.unescape(link), safe=safe))
+    return html.escape(quote(_unescape(link), safe=safe))
 
 
 def escape_html(s):
     if html is not None:
-        return html.escape(html.unescape(s)).replace('&#x27;', "'")
+        return html.escape(_unescape(s)).replace('&#x27;', "'")
     return escape(s)
 
 
 def unikey(s):
     return ' '.join(s.split()).lower()
+
+
+_charref = re.compile(r"&(?:#[0-9]+|#[xX][0-9a-fA-F]+|[^\t\n\f <&#;]{1,32});")
+
+
+def _unescape(s):
+    """Unescape HTML and numeric entities in string.
+
+    Python's `html.unescape`_ is quite aggressive in that it will recognize and
+    unescape as HTML entities character strings that *are not* terminated by a
+    semicolon.
+
+    The `HTML5 standard`_ is pretty clear the entities *must* be terminated by a
+    semicolon.
+
+    This essentially does the same thing as ``html.unescape`` except that it
+    requires that entities be terminated by semicolons.
+
+    Note that since the implementation of the function currently relies on
+    ``html.unescape``, it will only work under Python 3.
+
+    _html.unescape: https://docs.python.org/3/library/html.html#html.unescape
+    _HTML5 standard: https://html.spec.whatwg.org/multipage/syntax.html#character-references
+
+    """
+    return _charref.sub(lambda match: html.unescape(match.group(0)), s)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,10 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Text Processing :: Markup

--- a/tests/test_unescape.py
+++ b/tests/test_unescape.py
@@ -1,0 +1,16 @@
+import mistune
+from unittest import TestCase
+
+
+class TestMiscCases(TestCase):
+    def test_unescape_url(self):
+        md = mistune.create_markdown()
+        result = md('[&quotidian](search?c=x&section=1)')
+        expected = '<p><a href="search?c=x&section=1">&quotidian</a></p>'
+        self.assertEqual(result.strip().replace('&amp;', '&'), expected)
+
+    def test_unescape_alt(self):
+        md = mistune.create_markdown()
+        result = md('![&quotidian](quot.png)')
+        expected = '<p><img src="quot.png" alt="&quotidian" /></p>'
+        self.assertEqual(result.strip().replace('&amp;', '&'), expected)


### PR DESCRIPTION
This fixes #448 in which mistune 2.x (when running under python 3) is overzealous about unescaping HTML entities.