### PR TITLE
Escape quotes in MarkdownRenderer link and image titles

### DIFF
--- a/src/mistune/renderers/markdown.py
+++ b/src/mistune/renderers/markdown.py
@@ -32,7 +32,7 @@ class MarkdownRenderer(BaseRenderer):
             text = "[" + attrs["label"] + "]: " + attrs["url"]
             title = attrs.get("title")
             if title:
-                text += ' "' + title + '"'
+                text += ' "' + _escape_title(title) + '"'
             yield text
 
     def render_children(self, token: Dict[str, Any], state: BlockState) -> str:
@@ -71,7 +71,7 @@ class MarkdownRenderer(BaseRenderer):
         else:
             out += url
         if title:
-            out += ' "' + title + '"'
+            out += ' "' + _escape_title(title) + '"'
         return out + ")"
 
     def image(self, token: Dict[str, Any], state: BlockState) -> str:
@@ -186,6 +186,13 @@ class MarkdownRenderer(BaseRenderer):
 
     def table_cell(self, token: Dict[str, Any], state: BlockState) -> str:
         return _render_table_cell(self, token, state)
+
+
+def _escape_title(title: str) -> str:
+    """Escape a link/image title for emission inside double quotes. The closing
+    quote would otherwise end the title early on a re-parse; a backslash is
+    escaped first so it can't combine with the following character."""
+    return title.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _escape_block_prefix(text: str) -> str:

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -58,6 +58,18 @@ class TestMarkdownRendererRoundTrip(TestCase):
         ):
             self.assert_round_trip(text)
 
+    def test_link_title_containing_quote(self):
+        # a double quote inside a link/image title must be escaped, or the
+        # re-parse closes the title early and drops it
+        for text in (
+            "[t](/u 'say \"hi\"')\n",
+            '[t](/u "say \\"hi\\"")\n',
+            "![a](/u 'say \"hi\"')\n",
+            "[t][r]\n\n[r]: /u 'say \"hi\"'\n",
+            '[t](/u "back\\\\slash \\" quote")\n',
+        ):
+            self.assert_round_trip(text)
+
     def test_real_markers_preserved(self):
         for text in (
             "* bullet\n",


### PR DESCRIPTION
The `MarkdownRenderer` wraps link and image titles in double quotes but never escapes a quote inside the title, so a title containing one round-trips into broken Markdown:

```python
>>> md = mistune.create_markdown(renderer=MarkdownRenderer())
>>> md("[t](/u 'a\"b')\n")
'[t](/u "a"b")\n'
```

Re-parsing that output closes the title at the embedded quote, so the title is silently dropped and the link can fail to parse. Reference-link titles (in `render_referrences`) and image titles hit the same thing.

I escape backslashes and then the closing quote before writing the title, the same way the renderer already keeps other special characters literal (codespan backticks, leading block markers). Added a round-trip test covering inline links, images and reference links, plus a title mixing a backslash with a quote.
