### PR TITLE
Keep a trailing ">" when reformatting block quotes

### DIFF
--- a/src/mistune/renderers/markdown.py
+++ b/src/mistune/renderers/markdown.py
@@ -131,8 +131,11 @@ class MarkdownRenderer(BaseRenderer):
         return marker2 + info + "\n" + code + marker2 + "\n\n"
 
     def block_quote(self, token: Dict[str, Any], state: BlockState) -> str:
-        text = indent(self.render_children(token, state), "> ", lambda _: True)
-        text = text.rstrip("> \n")
+        # strip the children's trailing blank lines first so the quote marker is
+        # not added to a dangling empty line; stripping it back off afterwards
+        # would also eat a ">" that ends the content (an autolink or HTML tag).
+        text = self.render_children(token, state).rstrip("\n")
+        text = indent(text, "> ", lambda _: True)
         return text + "\n\n"
 
     def block_html(self, token: Dict[str, Any], state: BlockState) -> str:

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -70,6 +70,19 @@ class TestMarkdownRendererRoundTrip(TestCase):
         ):
             self.assert_round_trip(text)
 
+    def test_block_quote_content_ending_in_gt(self):
+        # a block quote whose content ends with ">" (an autolink, an inline
+        # HTML tag, or a literal ">") must keep that character; it was being
+        # stripped along with the trailing quote marker
+        for text in (
+            "> <https://example.com>\n",
+            "> <b>raw</b>\n",
+            "> ends with a literal &gt; >\n",
+            "> > nested <https://example.com>\n",
+            "> first\n>\n> <https://example.com>\n",
+        ):
+            self.assert_round_trip(text)
+
     def test_real_markers_preserved(self):
         for text in (
             "* bullet\n",


### PR DESCRIPTION
Reformatting a block quote through `MarkdownRenderer` drops the last `>` of its content, so an autolink, an inline HTML tag, or a literal `>` comes out broken:

```python
>>> import mistune
>>> from mistune.renderers.markdown import MarkdownRenderer
>>> md = mistune.create_markdown(renderer=MarkdownRenderer())
>>> md("> <https://example.com>\n")
'> <https://example.com\n'
```

`block_quote` indents every line with `> ` (including the blank line a paragraph leaves at the end) and then calls `rstrip("> \n")` to remove that dangling marker. Since `rstrip` strips a character set, it also peels off a `>` that ends the content itself, so the reparse turns `<https://example.com>` into escaped text.

I strip the children's trailing blank lines before indenting, so the marker is never added to an empty trailing line and there's nothing to strip back off. Existing empty-line-inside-quote handling is unchanged.

Added round-trip cases for content ending in `>` (autolink, HTML tag, literal `>`, nested quote). Full test suite and `mypy --strict` pass.