### PR TITLE
fix: escape literal emphasis markers in MarkdownRenderer

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -3,6 +3,12 @@ Changelog
 
 Here is the full history of mistune v3.
 
+Unreleased
+----------
+
+* Escape literal ``*``/``_`` emphasis markers in the Markdown renderer so
+  round-tripping escaped text does not re-introduce emphasis.
+
 Version 3.3.2
 -------------
 

--- a/src/mistune/renderers/markdown.py
+++ b/src/mistune/renderers/markdown.py
@@ -40,9 +40,18 @@ class MarkdownRenderer(BaseRenderer):
         return self.render_tokens(children, state)
 
     def text(self, token: Dict[str, Any], state: BlockState) -> str:
+        raw = cast(str, token["raw"])
+        # a text token that is made up entirely of "*"/"_" is a literal
+        # emphasis delimiter -- either an escaped marker from the source
+        # (``\*``) or an unmatched leftover -- so every character must stay
+        # escaped, or it would re-parse as emphasis on the round-trip. Prose
+        # punctuation such as ``2 * 3`` or ``snake_case`` arrives mixed with
+        # other characters and is left untouched.
+        if raw and all(c in "*_" for c in raw):
+            return "".join("\\" + c for c in raw)
         # a backtick always opens a code span, so it must stay escaped to
         # survive a re-parse as literal text.
-        return cast(str, token["raw"]).replace("`", "\\`")
+        return raw.replace("`", "\\`")
 
     def emphasis(self, token: Dict[str, Any], state: BlockState) -> str:
         return "*" + self.render_children(token, state) + "*"

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -46,6 +46,35 @@ class TestMarkdownRendererRoundTrip(TestCase):
     def test_escaped_backtick(self):
         self.assert_round_trip(r"\`not code\`" + "\n")
 
+    def test_escaped_emphasis_markers(self):
+        # an escaped "*"/"_" is a literal delimiter, not emphasis; re-emitting
+        # it unescaped would turn plain text back into <em>/<strong>
+        for text in (
+            r"\*not emphasis\*" + "\n",
+            r"\_not emphasis\_" + "\n",
+            r"\*\*not strong\*\*" + "\n",
+            r"\_\_not strong\_\_" + "\n",
+            r"a word\_with\_underscores" + "\n",
+            r"2 \* 3 \* 4" + "\n",
+            r"trailing star\*" + "\n",
+            r"\*leading star" + "\n",
+        ):
+            self.assert_round_trip(text)
+
+    def test_real_emphasis_not_over_escaped(self):
+        # genuine emphasis must survive untouched, and prose punctuation with
+        # spaces around a "*"/"_" must not gain stray backslashes
+        for text in (
+            "*emphasis*\n",
+            "**strong**\n",
+            "***both***\n",
+            "_under_ and __strong__\n",
+            "a *b* and _c_ mixed\n",
+            "2 * 3 = 6 and 4 * 5\n",
+            "snake_case_variable\n",
+        ):
+            self.assert_round_trip(text)
+
     def test_codespan_containing_backticks(self):
         # the delimiter must grow past any backtick run inside the code span,
         # and pad away a leading/trailing backtick, or the re-parse breaks


### PR DESCRIPTION
## Summary

`MarkdownRenderer.text()` only escapes backticks. A text token that is a **literal `*`/`_` emphasis delimiter** was emitted unescaped, so it re-parsed as emphasis on the round-trip — silently changing the document's meaning. This violates the invariant `TestMarkdownRendererRoundTrip` asserts: *"Reformatting valid Markdown must not change its meaning."*

## Reproduce

```python
import mistune
from mistune.renderers.markdown import MarkdownRenderer

reformat = mistune.create_markdown(renderer=MarkdownRenderer())
to_html  = mistune.create_markdown(escape=False)

src = r"\*not emphasis\*"          # escaped stars = literal text
print(reformat(src))               # -> '*not emphasis*\n'   (backslashes dropped)
print(to_html(src))                # -> '<p>*not emphasis*</p>\n'
print(to_html(reformat(src)))      # -> '<p><em>not emphasis</em></p>\n'   BUG
```

The reformatted Markdown renders to **different HTML** than the original. The same happened for `\_..\_`, `\*\*..\*\*`, `\_\_..\_\_`, and unmatched leftover markers.

### Root cause

When the inline parser consumes an escape (`\*`), it stores the bare character (`*`) as a text token and drops its internal no-emphasis flag before the AST is built, so the renderer cannot tell an escaped marker from an unmatched one. Either way the token is a **literal delimiter** and must be re-escaped, exactly like the backtick already is one line below (a backtick "always opens a code span, so it must stay escaped").

## Fix

In `text()`, if a text token consists **entirely** of `*`/`_`, backslash-escape each character. This is the sibling of the existing backtick handling and of the v3.3.0 change *"Escape leading block markers in Markdown renderer"* (this is the inline-marker counterpart).

Prose punctuation such as `2 * 3` or `snake_case` always arrives **mixed** with other characters in a single text token, so it is left untouched — no over-escaping (guarded by the existing `test_prose_not_over_escaped` and a new `test_real_emphasis_not_over_escaped`).

| input | before (`reformat` → HTML) | after |
| --- | --- | --- |
| `\*not emphasis\*` | `<em>not emphasis</em>` ❌ | `*not emphasis*` ✅ |
| `\_\_not strong\_\_` | `<strong>not strong</strong>` ❌ | `__not strong__` ✅ |
| `*emphasis*` | `<em>emphasis</em>` ✅ | `<em>emphasis</em>` ✅ (unchanged) |
| `2 * 3 = 6` | `2 * 3 = 6` ✅ | `2 * 3 = 6` ✅ (not over-escaped) |
| `snake_case_variable` | `snake_case_variable` ✅ | `snake_case_variable` ✅ (not over-escaped) |

## Tests

Added `test_escaped_emphasis_markers` and `test_real_emphasis_not_over_escaped` to `TestMarkdownRendererRoundTrip`. Proven to guard the bug by stashing only the source change:

- **without** the source fix: `test_escaped_emphasis_markers` **FAILS** — `AssertionError: '<p><em>not emphasis</em></p>\n' != '<p>*not emphasis*</p>\n'`
- **with** the fix: **PASSES**

```
$ python -m pytest -q
1122 passed, 3 subtests passed
$ ruff check src/mistune/renderers/markdown.py tests/test_renderers.py   # All checks passed!
$ ruff format --check ...                                                # already formatted
$ mypy src/mistune/renderers/markdown.py                                 # Success: no issues
```

Diff is +45/−1 across `src/mistune/renderers/markdown.py`, `tests/test_renderers.py`, and a `docs/changes.rst` entry.
