### PR TITLE
Only relax the indent bound when recompiling list break rules

### DIFF
--- a/src/mistune/list_parser.py
+++ b/src/mistune/list_parser.py
@@ -233,8 +233,11 @@ def _build_list_item_source(text: str, src: str, continue_width: int) -> str:
 def _compile_list_break_sc(block: "BlockParser", leading_width: int) -> Pattern[str]:
     pairs = [(name, block.specification[name]) for name in _get_list_break_rules(block)]
     if leading_width < 3:
-        _repl_w = str(leading_width)
-        pairs = [(n, p.replace("3", _repl_w, 1)) for n, p in pairs]
+        # Relax the leading indent bound only. Matching on a bare "3" would
+        # rewrite the first quantifier of any rule that has no indent prefix --
+        # e.g. a fenced directive's "{3,}" marker run.
+        _repl = " {0,%d}" % leading_width
+        pairs = [(n, p.replace(" {0,3}", _repl, 1)) for n, p in pairs]
 
     regex = "|".join(r"(?P<%s>(?<=\n)%s)" % pair for pair in pairs)
     return re.compile(regex, re.M)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -76,6 +76,29 @@ class TestCustomizeToc(BaseTestCase):
         self.assertIn('<a href="#t-1">h1</a>', html)
 
 
+class TestFencedDirectiveInList(BaseTestCase):
+    md = create_markdown(  # type: ignore[list-item]
+        escape=False,
+        plugins=[FencedDirective([Admonition()], markers=":")],
+    )
+
+    def test_marker_run_below_fence_length_is_not_a_directive(self):
+        # A directive needs three or more markers, inside a list item as well
+        # as outside one. The list break rules are recompiled per item, and a
+        # marker run shorter than the fence must stay literal text.
+        for text in (":{note}\nlazy\n", "100. item\n:{note}\nlazy\n"):
+            self.assertNotIn("admonition", self.md(text))
+
+        html = self.md("- item\n:{note}\nlazy\n")
+        self.assertNotIn("admonition", html)
+        self.assertIn(":{note}", html)
+
+    def test_directive_still_breaks_a_list(self):
+        html = self.md("- item\n:::{note}\nbody\n:::\n")
+        self.assertIn('<section class="admonition note">', html)
+        self.assertIn("<p>body</p>", html)
+
+
 class TestDirectiveInclude(BaseTestCase):
     md = create_markdown(escape=False, plugins=[RSTDirective([Include()])])  # type: ignore[list-item]
 


### PR DESCRIPTION
`_compile_list_break_sc` relaxes the break rules so a list item's own indent is accepted, by replacing the first literal `"3"` in each spec:

```python
if leading_width < 3:
    _repl_w = str(leading_width)
    pairs = [(n, p.replace("3", _repl_w, 1)) for n, p in pairs]
```

That assumes the first `"3"` is the leading ` {0,3}` indent bound. It is — for every rule that has one:

```
thematic_break    '^ {0,3}((?:-[ ...'
atx_heading       '^ {0,3}(?P<atx...'
block_quote       '^ {0,3}>(?P<qu...'
fenced_code       ... {0,3} ...
block_html        '^ {0,3}(...'
list              ... {0,3} ...
fenced_directive  '^(?P<fenced_directive_mark>(?::){3,})\{[a-zA-Z0-9_-]+\}'   ← no indent prefix
```

A fenced directive's spec has no indent prefix, so its first `"3"` is the marker-run quantifier. The recompiled rule for a `- ` item is:

```
leading_width=1 → (?P<fenced_directive_mark>(?::){1,})   # a single marker opens a directive
leading_width=2 → (?P<fenced_directive_mark>(?::){2,})
leading_width=3 → (?P<fenced_directive_mark>(?::){3,})   # untouched
```

### What it looks like

```python
md = mistune.create_markdown(plugins=[FencedDirective([Admonition()], markers=":")])

md(":{note}\nlazy\n")                 # <p>:{note}\nlazy</p>                          — correct
md("100. item\n:{note}\nlazy\n")      # <ol start="100"><li>item\n:{note}\nlazy</li>  — correct
md("- item\n:{note}\nlazy\n")         # <ul><li>item</li></ul>
                                      # <section class="admonition note">
                                      # <p class="admonition-title">Note</p><p>lazy</p></section>
```

One colon isn't a directive, so `:{note}` should stay literal — as it does at the top level and inside `100. ` (`leading_width >= 3`, so no rewrite). Inside `- ` the text is dropped, an admonition is invented, and the list is terminated early. `_process_directive` then builds its closing fence from the same relaxed length, so it swallows to the next marker line.

`markers="`"` shows the same shape on ordinary inline code: `` `{note}` is a template `` inside a `- ` item turns into an admonition.

### The change

Anchor the replacement to the ` {0,3}` substring. I checked each break rule both ways: the six rules that have an indent prefix compile **byte-identically** to before at `leading_width` 1 and 2, and `fenced_directive` is the only one that differs — it now keeps `{3,}`.

Adding a ` {0,3}` prefix to `directive_pattern` would fix this instance too, but it leaves the mechanism resting on "the first 3 is always the indent bound". Worth noting the open `EnhancedDirective` work in #435 introduces another `{3,}` pattern with no indent prefix, which would land in the same trap.

**Scope:** default markers are unaffected — they take the `register("fenced_code", ...)` path and register no `fenced_directive` spec. This only bites custom markers, e.g. the MyST-style `markers=":"` that `docs/directives.rst` cites as the inspiration.

### Testing

- `TestFencedDirectiveInList::test_marker_run_below_fence_length_is_not_a_directive` fails on `main` (`'admonition' unexpectedly found in ...`) and passes with the change. It pins the top-level and `100. ` cases as controls, so it can't pass by disabling the feature.
- `test_directive_still_breaks_a_list` covers the positive direction — `:::{note}` must still break out of a list. It passes both before and after.
- Full suite: **1139 passed** (1137 before + these 2), including all 652 CommonMark examples.
- `ruff check`, `ruff format --check`, and `mypy src/mistune/list_parser.py` are clean.

Disclosure: I used an AI coding assistant to find this. The repros, the per-rule regex comparison, and the test runs are ones I did myself against this branch; happy to answer anything about it.
