### PR TITLE
fix: keep escaped backslashes in angle-bracket link destinations

### DIFF
--- a/src/mistune/helpers.py
+++ b/src/mistune/helpers.py
@@ -242,7 +242,10 @@ def _parse_angle_link_href(src: str, pos: int) -> Union[Tuple[str, int], Tuple[N
         c = src[pos]
         if c == ">":
             return src[start:pos], pos + 1
-        if c in "<\\\n\r\x00":
+        if c == "\\":
+            pos = min(pos + 2, len(src))
+            continue
+        if c in "<\n\r\x00":
             return None, None
         pos += 1
     return None, None

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -134,6 +134,14 @@ class TestMiscCases(TestCase):
         for text, html in cases.items():
             self.assertEqual(mistune.html(text).strip(), html)
 
+    def test_angle_link_escaped_backslash(self):
+        cases = {
+            r"[link](<foo\*bar>)": '<p><a href="foo*bar">link</a></p>',
+            "[x]: <a\\*b>\n\n[x]": '<p><a href="a*b">x</a></p>',
+        }
+        for text, html in cases.items():
+            self.assertEqual(mistune.html(text).strip(), html, text)
+
     def test_allow_harmful_protocols(self):
         renderer = mistune.HTMLRenderer(allow_harmful_protocols=True)
         md = mistune.Markdown(renderer)


### PR DESCRIPTION
### The bug

A link (or reference definition) whose angle-bracket destination contains a backslash silently degrades to literal text:

    [link](<foo\*bar>)   ->  <p>[link](&lt;foo*bar&gt;)</p>    (expected: <a href="foo*bar">link</a>)
    [x]: <a\*b>          ->  ref-def dropped, and every [x] that references it breaks too

### Root cause

`_parse_angle_link_href` lists `\` in its reject set:

```python
if c in "<\\\n\r\x00":
    return None, None
```

so the first backslash makes it bail and the whole link construct falls back to literal text. The sibling bare-destination branch in `parse_link_href` already consumes `\` + the next char, and `parse_link` runs the slice through `unescape_char`, so the escape machinery was already in place — only this branch refused to feed it. CommonMark allows an escaped `<`/`>` inside an angle-bracket destination.

### The fix

Consume `\` + the next char as a unit, exactly like the bare-destination branch. An unescaped `<`, line ending, or NUL still terminates the destination as before.

### Verification

Added `test_angle_link_escaped_backslash` (red before this change, green after). `pytest tests/` stays green — 1140 passed, including the 652-case CommonMark fixture. The two asserted outputs match both `commonmark` (cmark) and `markdown-it-py`.

---
Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran the repro, wrote the fix and the test, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff — it was just done by the AI, not a person. If this isn't the kind of contribution you want, say so and I'll close it.

