### PR TITLE
Only treat a backslash as an escape before punctuation in a link destination

### DIFF
--- a/src/mistune/helpers.py
+++ b/src/mistune/helpers.py
@@ -146,7 +146,7 @@ def parse_link_href(src: str, start_pos: int, block: bool = False) -> Union[Tupl
             break
         if c == "\x00":
             return None, None
-        if c == "\\":
+        if c == "\\" and pos + 1 < len(src) and src[pos + 1] in string.punctuation:
             pos = min(pos + 2, len(src))
             continue
         if not block:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -91,6 +91,19 @@ class TestMiscCases(TestCase):
         expected = '<p><a href="#harmful-link">h</a></p>'
         self.assertEqual(result.strip(), expected)
 
+    def test_backslash_space_in_link_destination_is_not_an_escape(self):
+        # A space is not ASCII punctuation, so "\ " is a literal backslash and a
+        # space that ends the bare destination: the link fails to parse and is
+        # rendered as text (as CommonMark and other parsers do). Previously the
+        # scanner treated "\ " as an escape and swallowed the space into the URL,
+        # producing an illegal href containing %5C%20.
+        result = mistune.html(r"[a](foo\ bar)")
+        self.assertEqual(result.strip(), r"<p>[a](foo\ bar)</p>")
+
+        # An escaped punctuation character is still consumed as an escape.
+        result = mistune.html(r"[a](foo\*bar)")
+        self.assertEqual(result.strip(), '<p><a href="foo*bar">a</a></p>')
+
     def test_harmful_links_variants(self):
         # entity-decoded, alternate-scheme, and reference-link forms are all
         # routed to the #harmful-link sentinel.


### PR DESCRIPTION
### Problem

`[a](foo\ bar)` renders as a link with an illegal href:

```
[a](foo\ bar)   ->   <p><a href="foo%5C%20bar">a</a></p>
```

That href contains a backslash (`%5C`) and a space (`%20`), which no reading of the syntax should produce — CommonMark and other parsers render this input as literal text.

A space is not an escapable character, so `\ ` is a literal backslash followed by a space that should end the bare destination (and make the whole link fail to parse). But `parse_link_href`'s scanner (`helpers.py`) skips the character after *any* backslash, so the `\` hides the following space from the whitespace break, and the space is absorbed into the destination. The leftover `%5C` is the tell: the same module's `unescape_char` only unescapes a backslash before ASCII punctuation, so it refuses to remove this one — the scanner and the unescaper disagree about what is escapable.

### Fix

Gate the skip on the next character being punctuation, matching `unescape_char`:

```python
[a](foo\ bar)   ->   <p>[a](foo\ bar)</p>     # literal text, link fails to parse
[a](foo\*bar)   ->   <p><a href="foo*bar">a</a></p>   # escaped punctuation still works
```

### Tests

`test_backslash_space_in_link_destination_is_not_an_escape` covers both cases; it fails before this change and passes after. The full suite stays green (1140 passed, including the 652-example CommonMark set); `ruff check`, `ruff format`, and `mypy` pass.

*Scope note:* this only changes the backslash-before-non-punctuation case in a bare destination. Adjacent behaviours where reference parsers themselves disagree (e.g. a backslash inside a `(title)`/`"title"`) are intentionally untouched.

---

*Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, wrote and ran the repro and the test, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*

