### PR TITLE
fix(def_list): a tab after the ':' marker no longer makes the definition a code block

### DIFF
--- a/src/mistune/plugins/def_list.py
+++ b/src/mistune/plugins/def_list.py
@@ -14,6 +14,7 @@ __all__ = ["def_list"]
 
 DEF_PATTERN = r"^:[ \t]+.*(?:\n|$)"
 DD_START_RE = re.compile(r"^:[ \t]+", re.M)
+DD_MARKER_RE = re.compile(r"^:[ \t]")
 TRIM_RE = re.compile(r"^ {0,4}", re.M)
 HAS_BLANK_LINE_RE = re.compile(r"\n[ \t]*\n$")
 
@@ -105,7 +106,9 @@ def _collect_definitions(src: str, pos: int, max_pos: int, loose: bool) -> Tuple
         start = pos
         pos += len(line)
         pos = _scan_definition_tail(src, pos, max_pos)
-        text = src[start:pos].replace(":", " ", 1)
+        # drop the ':' marker plus its trailing space or tab; a tab here would
+        # otherwise survive TRIM_RE (spaces only) and make the line a code block
+        text = DD_MARKER_RE.sub("  ", src[start:pos], count=1)
         definitions.append((text, loose))
         loose = bool(HAS_BLANK_LINE_RE.search(text))
 

--- a/tests/fixtures/def_list.txt
+++ b/tests/fixtures/def_list.txt
@@ -213,3 +213,16 @@ Term
 </dd>
 </dl>
 ````````````````````````````````
+
+
+## Tab-Marked Definition
+
+```````````````````````````````` example
+Term
+:	Tab-marked def
+.
+<dl>
+<dt>Term</dt>
+<dd>Tab-marked def</dd>
+</dl>
+````````````````````````````````


### PR DESCRIPTION
## The bug

A definition whose `:` marker is followed by a **tab** renders as a code block instead of a definition:

```python
import mistune
md = mistune.create_markdown(plugins=['def_list'])
print(md("Term\n:\tTab-marked def\n"))
```

Today:

```html
<dl>
<dt>Term</dt>
<dd><pre><code>Tab-marked def</code></pre>
</dd>
</dl>
```

`DD_START_RE` (`^:[ \t]+`) explicitly accepts a tab as the marker separator, so this is meant to be an ordinary definition.

## Cause

`_collect_definitions` strips the marker with `src[start:pos].replace(":", " ", 1)` and then de-indents each line with `TRIM_RE = re.compile(r"^ {0,4}")` — **spaces only**. For `:\tdef`, replacing the colon leaves `" \tdef"`; `TRIM_RE` removes the one leading space but not the tab, so the line starts with a tab and is parsed as an indented code block.

## Fix

Drop the `:` marker together with its trailing space **or tab** in one step:

```python
DD_MARKER_RE = re.compile(r"^:[ \t]")
...
text = DD_MARKER_RE.sub("  ", src[start:pos], count=1)
```

For space markers this produces exactly the same string as before, so their output is unchanged. `TRIM_RE` is left alone, so continuation lines — including intentional tab-indented code blocks inside a definition — are untouched.

## Verification

- Added a `tests/fixtures/def_list.txt` example (a tab-marked definition). It fails on `main` and passes with this change, across the plain and `speedup` variants.
- Full suite green: `1137 passed`. Existing space-marked definitions, multi-line continuations, blank-line (loose) definitions, and tab-indented code blocks inside a definition all render as before.
- `ruff check` clean.

---

*Disclosure:* this PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the tests, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
