### PR TITLE
Preserve multi-line setext headings in MarkdownRenderer

### DIFF
--- a/src/mistune/renderers/markdown.py
+++ b/src/mistune/renderers/markdown.py
@@ -116,8 +116,17 @@ class MarkdownRenderer(BaseRenderer):
 
     def heading(self, token: Dict[str, Any], state: BlockState) -> str:
         level = cast(int, token["attrs"]["level"])
-        marker = "#" * level
         text = self.render_children(token, state)
+        # An ATX heading ("# ...") occupies a single line, so a heading whose
+        # rendered text spans several lines -- a multi-line setext heading --
+        # must be re-emitted in setext form. As ATX the continuation lines
+        # would fall out of the heading and become a paragraph on a re-parse.
+        # Only levels 1 and 2 reach this branch, since an ATX heading never
+        # contains a line break.
+        if "\n" in text and level in (1, 2):
+            underline = "=" if level == 1 else "-"
+            return text + "\n" + underline * 3 + "\n\n"
+        marker = "#" * level
         return marker + " " + text + "\n\n"
 
     def thematic_break(self, token: Dict[str, Any], state: BlockState) -> str:

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -112,6 +112,18 @@ class TestMarkdownRendererRoundTrip(TestCase):
         ):
             self.assert_round_trip(text)
 
+    def test_multiline_setext_heading(self):
+        # a setext heading may span several lines; re-emitting it as an ATX
+        # heading ("# ...") drops every line after the first out of the
+        # heading, because an ATX heading is a single line
+        for text in (
+            "Foo\nBar\n===\n",
+            "Foo\nBar\n---\n",
+            "one\ntwo\nthree\n===\n",
+            "Foo *bar\nbaz*\n====\n",
+        ):
+            self.assert_round_trip(text)
+
     def test_real_markers_preserved(self):
         for text in (
             "* bullet\n",


### PR DESCRIPTION
Reformatting a multi-line setext heading through MarkdownRenderer changes its meaning. A heading like

    Foo
    Bar
    ===

comes back as "## Foo" plus a separate "Bar" paragraph, because the renderer always emits an ATX heading ("# ...") and an ATX heading is a single line, so every line after the first drops out of the heading on a re-parse.

The `heading` method now emits setext form ("===" / "---" underline) when the rendered text spans multiple lines. Only levels 1 and 2 can reach that case, since an ATX heading never contains a line break. Added a round-trip test covering plain and emphasis-spanning multi-line headings.