### PR TITLE
fix: apply escape flag to a user-supplied HTML renderer

### DIFF
--- a/src/mistune/__init__.py
+++ b/src/mistune/__init__.py
@@ -22,14 +22,15 @@ RendererRef = Union[Literal["html", "ast"], BaseRenderer]
 
 
 def create_markdown(
-    escape: bool = True,
+    escape: Optional[bool] = None,
     hard_wrap: bool = False,
     renderer: Optional[RendererRef] = "html",
     plugins: Optional[Iterable[PluginRef]] = None,
 ) -> Markdown:
     """Create a Markdown instance based on the given condition.
 
-    :param escape: Boolean. If using html renderer, escape html.
+    :param escape: Boolean. If using html renderer, escape html. When it is
+        ``None``, the renderer keeps its own escape setting.
     :param hard_wrap: Boolean. Break every new line into ``<br>``.
     :param renderer: renderer instance, default is HTMLRenderer.
     :param plugins: List of plugins.
@@ -47,7 +48,10 @@ def create_markdown(
         # explicit and more similar to 2.x's API
         renderer = None
     elif renderer == "html":
-        renderer = HTMLRenderer(escape=escape)
+        renderer = HTMLRenderer(escape=True if escape is None else escape)
+    elif escape is not None and isinstance(renderer, HTMLRenderer):
+        # a renderer instance was given, honor the explicit escape flag
+        renderer._escape = escape
 
     inline = InlineParser(hard_wrap=hard_wrap)
     real_plugins: Optional[Iterable[Plugin]] = None

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -17,6 +17,20 @@ class TestMiscCases(TestCase):
         md.parse("", state)
         self.assertEqual(state.env["name"], "test")
 
+    def test_escape_applies_to_custom_renderer(self):
+        class CustomRenderer(mistune.HTMLRenderer):
+            pass
+
+        md = mistune.create_markdown(renderer=CustomRenderer(), escape=False)
+        self.assertEqual(md("<b>hi</b>").strip(), "<p><b>hi</b></p>")
+
+        md = mistune.create_markdown(renderer=CustomRenderer(escape=False), escape=True)
+        self.assertEqual(md("<b>hi</b>").strip(), "<p>&lt;b&gt;hi&lt;/b&gt;</p>")
+
+        # without an explicit escape flag the renderer keeps its own setting
+        md = mistune.create_markdown(renderer=CustomRenderer(escape=False))
+        self.assertEqual(md("<b>hi</b>").strip(), "<p><b>hi</b></p>")
+
     def test_hard_wrap(self):
         md = mistune.create_markdown(escape=False, hard_wrap=True)
         result = md("foo\nbar")


### PR DESCRIPTION
Closes #420

`create_markdown()` only passed `escape` to the renderer it constructed itself, so `create_markdown(renderer=MyRenderer(), escape=False)` silently kept escaping HTML.

`escape` now defaults to `None` ("keep the renderer's own setting") and an explicit `True`/`False` is applied to a supplied `HTMLRenderer` instance too. Existing calls are unaffected: the default renderer still escapes by default.
